### PR TITLE
Clean up pipeline_marker and identity marker

### DIFF
--- a/tensorflow/compiler/xla/python/ops.cc
+++ b/tensorflow/compiler/xla/python/ops.cc
@@ -209,23 +209,6 @@ void BuildOpsSubmodule(py::module* m) {
       py::arg("output_operand_aliasing"), py::arg("literal") = nullptr,
       py::arg("schedule") = CustomCallSchedule::SCHEDULE_NONE,
       py::arg("api_version") = CustomCallApiVersion::API_VERSION_ORIGINAL);
-  ops.def(
-      "CustomCallWithOnlyAliasing",
-      [](XlaBuilder* builder, const py::bytes& call_target_name,
-         absl::Span<const XlaOp> operands, const Shape& shape,
-         const py::bytes& opaque, bool has_side_effect,
-         absl::Span<const std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>
-             output_operand_aliasing,
-         CustomCallSchedule schedule) -> XlaOp {
-        return CustomCall(builder, call_target_name, operands, shape, opaque,
-                          has_side_effect,
-                          /*output_operand_aliasing=*/output_operand_aliasing,
-                          /*literal=*/nullptr, schedule);
-      },
-      py::arg("builder"), py::arg("call_target_name"), py::arg("operands"),
-      py::arg("shape"), py::arg("opaque") = py::bytes(""),
-      py::arg("has_side_effect") = false, py::arg("output_operand_aliasing"),
-      py::arg("schedule") = CustomCallSchedule::SCHEDULE_NONE);
   ops.def("Dot", &Dot, py::arg("lhs"), py::arg("rhs"),
           py::arg("precision_config") = nullptr,
           py::arg("preferred_element_type") = absl::nullopt);

--- a/tensorflow/compiler/xla/service/BUILD
+++ b/tensorflow/compiler/xla/service/BUILD
@@ -6345,6 +6345,7 @@ cc_library(
     deps = [
         ":hlo",
         ":hlo_pass",
+        "//tensorflow/compiler/xla:shape_util",
     ],
 )
 

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_util.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_util.cc
@@ -18,7 +18,7 @@ NullStream& NullStream::Global() {
   return stream;
 }
 
-const char* const kXlaPipelineMarker = "xla_pipeline_marker";
+const char* const kPipelineMarker = "pipeline_marker";
 const char* const kIdentityMarker = "identity";
 
 // Return whether a reshape instruction is a special reshape that switches
@@ -109,7 +109,7 @@ bool IsActivationFromAnotherStage(const HloInstruction* ins,
 
   for (const HloInstruction* user : ins->users()) {
     if (!(user->opcode() == HloOpcode::kTuple && user->users().size() == 1 &&
-          user->users().front()->IsCustomCall(kXlaPipelineMarker) &&
+          user->users().front()->IsCustomCall(kPipelineMarker) &&
           user->users().front()->metadata().op_type().find("start") !=
               std::string::npos)) {
       return false;
@@ -339,7 +339,7 @@ InstructionBatchDimMap BuildInstructionBatchDimMap(
       }
     }
 
-    if (ins->IsCustomCall(kXlaPipelineMarker) &&
+    if (ins->IsCustomCall(kPipelineMarker) &&
         ins->metadata().op_type().find("start") != std::string::npos) {
       // Reset the status after meet a new pipeline marker.
       set_the_next_dot_conv = true;

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_util.h
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_util.h
@@ -27,7 +27,7 @@ using ReshardingCache =
     absl::flat_hash_map<const HloInstruction*,
                         std::vector<std::pair<HloSharding, HloInstruction*>>>;
 
-extern const char* const kXlaPipelineMarker;
+extern const char* const kPipelineMarker;
 extern const char* const kIdentityMarker;
 constexpr absl::string_view kPipelineMarkerStartType = "start";
 constexpr absl::string_view kPipelineMarkerEndType = "end";
@@ -243,7 +243,7 @@ inline void ReplaceOperand(HloInstruction* inst,
 
 // Return whether this instruction is a custom call marker introduced by us.
 inline bool IsCustomCallMarker(const HloInstruction* inst) {
-  return inst->IsCustomCall(kXlaPipelineMarker) ||
+  return inst->IsCustomCall(kPipelineMarker) ||
          inst->IsCustomCall(kIdentityMarker);
 }
 
@@ -372,7 +372,7 @@ inline std::vector<const HloInstruction*> GetGradientComputationInstructions(
   for (size_t i = 0; i < instructions.size(); ++i) {
     const HloInstruction* ins = instructions[i];
 
-    if (ins->IsCustomCall(kXlaPipelineMarker) &&
+    if (ins->IsCustomCall(kPipelineMarker) &&
         (ins->metadata().op_name().find("compute_grad") != std::string::npos ||
          ins->metadata().op_name().find("backward") != std::string::npos) &&
         ins->metadata().op_type() == kPipelineMarkerEndType) {


### PR DESCRIPTION
- Rename `xla_pipeline_marker` to `pipeline_marker`
- Remove `CustomCallWithOnlyAliasing` and use a custom pass (`tensorflow/compiler/xla/service/remat_identity_fixer.cc`) to set the alias for `pipeline_marker` and `identity`, because the alias setting might be dropped during jaxpr->HLO conversion.