### PR TITLE
Fix the strategy registration for elementwise instructions without following

### DIFF
--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_strategy.h
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_strategy.h
@@ -1005,6 +1005,8 @@ std::unique_ptr<StrategyVector> CreateLeafStrategyVector(
     size_t instruction_id, const HloInstruction* ins,
     const StrategyMap& strategy_map, LeafStrategies& leaf_strategies);
 
+void RemoveDuplicatedStrategy(std::unique_ptr<StrategyVector>& strategies);
+
 Status FilterStrategy(const HloInstruction* ins,
                       std::unique_ptr<StrategyVector>& strategies,
                       const ClusterEnvironment& cluster_env,


### PR DESCRIPTION
For elementwise instructions, if there are two operands with very close priorities (i.e. depth), then we cannot easily choose which one to follow. Previously, we only copy the sharding specs from one chosen operand, which may miss some possible sharding specs. In this PR, we copy all sharding specs from all operands in this case, so we can capture all possible sharding specs.