### PR TITLE
Normalize the dot dimensions

### DIFF
--- a/tensorflow/compiler/xla/service/reduce_scatter_utils.cc
+++ b/tensorflow/compiler/xla/service/reduce_scatter_utils.cc
@@ -393,6 +393,7 @@ absl::optional<ReduceScatterSpec> MatchReduceScatter(
   std::vector<int64_t> split_dims;
   // First find a single dimension where the input and output of dynamic slice
   // differ.
+  CHECK_EQ(ar->shape().rank(), user->shape().rank());
   int num_dims = 0;
   for (int64_t dim = 0; dim < ar->shape().rank(); ++dim) {
     if (ar->shape().dimensions(dim) == user->shape().dimensions(dim)) {

--- a/tensorflow/compiler/xla/service/spmd/BUILD
+++ b/tensorflow/compiler/xla/service/spmd/BUILD
@@ -188,6 +188,7 @@ cc_library(
         "//tensorflow/compiler/xla:shape_util",
         "//tensorflow/compiler/xla/service:dump",
         "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service:hlo_creation_utils",
         "//tensorflow/compiler/xla/service:hlo_live_range",
         "//tensorflow/compiler/xla/service:hlo_memory_scheduler",
         "//tensorflow/compiler/xla/service:hlo_pass",

--- a/tensorflow/compiler/xla/service/spmd/alpa_compile.cc
+++ b/tensorflow/compiler/xla/service/spmd/alpa_compile.cc
@@ -36,8 +36,8 @@ namespace xla {
 
 namespace spmd {
 
-const char kBeforeAutoShardingDumpName[] = "before_auto_sharding";
-const char kBeforeSpmdPartitionDumpName[] = "before_spmd_partitioning";
+const char kBeforeAutoShardingDumpName[] = "before_run_auto_sharding";
+const char kBeforeSpmdPartitionDumpName[] = "before_run_spmd_partitioner";
 // TODO(yonghao): Check correctness of compile options and modules
 Status PreCompileCheck(const XlaComputation& computation,
                        CompileOptions options) {
@@ -120,6 +120,7 @@ StatusOr<std::shared_ptr<xla::HloModule>> RunAutoShardingPass(
       // "slow" minmax means we propagate nan.
       options.set_minmax_propagate_nan(
           !debug_options.xla_gpu_enable_fast_min_max());
+      options.set_enable_dot_strength_reduction(false);
       spmd_simplify.AddPass<AlgebraicSimplifier>(options);
 
       spmd_simplify.AddPass<SortSimplifier>();

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
@@ -2158,7 +2158,7 @@ StatusOr<bool> AutoSharding::Run(HloModule* module) {
   // std::cerr << "=====================================" << std::endl;
 
   // ----- Pre-process to normalize the dot dimensions -----
-  NormalizeDotDimension(module);
+  TF_ASSIGN_OR_RETURN(bool changed, NormalizeDotDimension(module));
 
   // ----- Get a sequential schedule and do liveness analysis -----
   auto size_fn = [](const BufferValue& buffer) {

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
@@ -2157,6 +2157,9 @@ StatusOr<bool> AutoSharding::Run(HloModule* module) {
   // std::cerr << module->ToString();
   // std::cerr << "=====================================" << std::endl;
 
+  // ----- Pre-process to normalize the dot dimensions -----
+  NormalizeDotDimension(module);
+
   // ----- Get a sequential schedule and do liveness analysis -----
   auto size_fn = [](const BufferValue& buffer) {
     return GetBytes(buffer.shape());

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_dot_handler.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_dot_handler.cc
@@ -61,7 +61,8 @@ class DotHandler {
     CHECK_EQ(lhs_con_dims.size(), 1);
     CHECK_EQ(rhs_con_dims.size(), 1);
 
-    // The dimension in the output that corresponds to the lhs space dim or rhs space dim
+    // The dimension in the output that corresponds to the lhs space dim or rhs
+    // space dim
     out_lhs_space_dim = dot_dnums.lhs_batch_dimensions_size();
     out_rhs_space_dim = out_lhs_space_dim + 1;
 
@@ -70,8 +71,10 @@ class DotHandler {
   }
 
   void SplitLhsSpaceRhsSpace(int mesh_dim0, int mesh_dim1) {
-     if (ins->shape().dimensions(out_lhs_space_dim) < device_mesh.dim(mesh_dim0) ||
-         ins->shape().dimensions(out_rhs_space_dim) < device_mesh.dim(mesh_dim1)) {
+    if (ins->shape().dimensions(out_lhs_space_dim) <
+            device_mesh.dim(mesh_dim0) ||
+        ins->shape().dimensions(out_rhs_space_dim) <
+            device_mesh.dim(mesh_dim1)) {
       return;  // Do not allow padding the output tensor
     }
 
@@ -90,7 +93,8 @@ class DotHandler {
   }
 
   void SplitLhsSpaceBothContract(int mesh_dim0, int mesh_dim1) {
-    if (lhs->shape().dimensions(out_lhs_space_dim) < device_mesh.dim(mesh_dim0)) {
+    if (lhs->shape().dimensions(out_lhs_space_dim) <
+        device_mesh.dim(mesh_dim0)) {
       return;  // Do not allow padding the output tensor
     }
 
@@ -116,7 +120,8 @@ class DotHandler {
   }
 
   void SplitRhsSpaceBothContract(int mesh_dim0, int mesh_dim1) {
-    if (ins->shape().dimensions(out_rhs_space_dim) < device_mesh.dim(mesh_dim1)) {
+    if (ins->shape().dimensions(out_rhs_space_dim) <
+        device_mesh.dim(mesh_dim1)) {
       return;  // Do not allow padding the output tensor
     }
 

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_dot_handler.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_dot_handler.cc
@@ -56,8 +56,8 @@ class DotHandler {
     std::tie(lhs_space_dims, rhs_space_dims) =
         GetSpaceDims(lhs->shape(), rhs->shape(), dot_dnums);
 
-    CHECK_EQ(lhs_space_dims.size(), 1);
-    CHECK_EQ(rhs_space_dims.size(), 1);
+    CHECK_EQ(lhs_space_dims.size(), 1) << ins->ToString();
+    CHECK_EQ(rhs_space_dims.size(), 1) << ins->ToString();
     CHECK_EQ(lhs_con_dims.size(), 1);
     CHECK_EQ(rhs_con_dims.size(), 1);
 

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_dot_handler.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_dot_handler.cc
@@ -49,11 +49,10 @@ class DotHandler {
         lhs(ins->operand(0)),
         rhs(ins->operand(1)),
         dot_dnums(ins->dot_dimension_numbers()),
-        space_base_dim(dot_dnums.lhs_batch_dimensions_size()),
-        lhs_con_dims(ins->dot_dimension_numbers().lhs_contracting_dimensions()),
-        rhs_con_dims(ins->dot_dimension_numbers().rhs_contracting_dimensions()),
-        lhs_batch_dims(ins->dot_dimension_numbers().lhs_batch_dimensions()),
-        rhs_batch_dims(ins->dot_dimension_numbers().rhs_batch_dimensions()) {
+        lhs_con_dims(dot_dnums.lhs_contracting_dimensions()),
+        rhs_con_dims(dot_dnums.rhs_contracting_dimensions()),
+        lhs_batch_dims(dot_dnums.lhs_batch_dimensions()),
+        rhs_batch_dims(dot_dnums.rhs_batch_dimensions()) {
     std::tie(lhs_space_dims, rhs_space_dims) =
         GetSpaceDims(lhs->shape(), rhs->shape(), dot_dnums);
 
@@ -62,22 +61,24 @@ class DotHandler {
     CHECK_EQ(lhs_con_dims.size(), 1);
     CHECK_EQ(rhs_con_dims.size(), 1);
 
+    // The dimension in the output that corresponds to the lhs space dim or rhs space dim
+    out_lhs_space_dim = dot_dnums.lhs_batch_dimensions_size();
+    out_rhs_space_dim = out_lhs_space_dim + 1;
+
     // Only support 2 dimensional device mesh
     CHECK_EQ(device_mesh.num_dimensions(), 2);
   }
 
   void SplitLhsSpaceRhsSpace(int mesh_dim0, int mesh_dim1) {
-    // if (ins->shape().dimensions(space_base_dim) < device_mesh.dim(mesh_dim0)
-    // ||
-    //    ins->shape().dimensions(space_base_dim + 1) <
-    //    device_mesh.dim(mesh_dim1)) {
-    //  return;  // The dimension length is to small to be parallelzied.
-    //}
+     if (ins->shape().dimensions(out_lhs_space_dim) < device_mesh.dim(mesh_dim0) ||
+         ins->shape().dimensions(out_rhs_space_dim) < device_mesh.dim(mesh_dim1)) {
+      return;  // Do not allow padding the output tensor
+    }
 
     std::string name =
         absl::StrFormat("SS = SR x RS @ {%d,%d}", mesh_dim0, mesh_dim1);
     HloSharding output_spec =
-        Tile(ins->shape(), {space_base_dim, space_base_dim + 1},
+        Tile(ins->shape(), {out_lhs_space_dim, out_rhs_space_dim},
              {mesh_dim0, mesh_dim1}, device_mesh);
     HloSharding lhs_spec =
         Tile(lhs->shape(), {lhs_space_dims[0]}, {mesh_dim0}, device_mesh);
@@ -89,19 +90,16 @@ class DotHandler {
   }
 
   void SplitLhsSpaceBothContract(int mesh_dim0, int mesh_dim1) {
-    // if (lhs->shape().dimensions(lhs_space_dims[0]) <
-    // device_mesh.dim(mesh_dim0) ||
-    //    lhs->shape().dimensions(lhs_con_dims[0]) < device_mesh.dim(mesh_dim1))
-    //    {
-    //  return;  // The dimension length is to small to be parallelzied.
-    //}
+    if (lhs->shape().dimensions(out_lhs_space_dim) < device_mesh.dim(mesh_dim0)) {
+      return;  // Do not allow padding the output tensor
+    }
 
     if (device_mesh.dim(mesh_dim0) > 1 && device_mesh.dim(mesh_dim1) > 1) {
       std::string name =
           absl::StrFormat("SR = SS x SR @ {%d,%d} (allreduce @ %d)", mesh_dim0,
                           mesh_dim1, mesh_dim1);
       HloSharding output_spec =
-          Tile(ins->shape(), {space_base_dim}, {mesh_dim0}, device_mesh);
+          Tile(ins->shape(), {out_lhs_space_dim}, {mesh_dim0}, device_mesh);
       HloSharding lhs_spec =
           Tile(lhs->shape(), {lhs_space_dims[0], lhs_con_dims[0]},
                {mesh_dim0, mesh_dim1}, device_mesh);
@@ -118,19 +116,16 @@ class DotHandler {
   }
 
   void SplitRhsSpaceBothContract(int mesh_dim0, int mesh_dim1) {
-    // if (rhs->shape().dimensions(rhs_con_dims[0]) < device_mesh.dim(mesh_dim0)
-    // ||
-    //    rhs->shape().dimensions(rhs_space_dims[0]) <
-    //    device_mesh.dim(mesh_dim1)) {
-    //  return;  // The dimension length is to small to be parallelzied.
-    //}
+    if (ins->shape().dimensions(out_rhs_space_dim) < device_mesh.dim(mesh_dim1)) {
+      return;  // Do not allow padding the output tensor
+    }
 
     if (device_mesh.dim(mesh_dim0) > 1) {
       std::string name =
           absl::StrFormat("RS = RS x SS @ {%d,%d} (allreduce @ %d)", mesh_dim0,
                           mesh_dim1, mesh_dim0);
       HloSharding output_spec =
-          Tile(ins->shape(), {space_base_dim + 1}, {mesh_dim1}, device_mesh);
+          Tile(ins->shape(), {out_rhs_space_dim}, {mesh_dim1}, device_mesh);
       HloSharding lhs_spec =
           Tile(lhs->shape(), {lhs_con_dims[0]}, {mesh_dim0}, device_mesh);
       HloSharding rhs_spec =
@@ -192,7 +187,7 @@ class DotHandler {
         device_mesh.dim(mesh_dim1) > 1) {
       std::string name =
           absl::StrFormat("SbSi = SbSi x SbR @ {%d,%d}", mesh_dim0, mesh_dim1);
-      HloSharding output_spec = Tile(ins->shape(), {0, space_base_dim},
+      HloSharding output_spec = Tile(ins->shape(), {0, out_lhs_space_dim},
                                      {mesh_dim0, mesh_dim1}, device_mesh);
       HloSharding lhs_spec =
           Tile(lhs->shape(), {lhs_batch_dims[0], lhs_space_dims[0]},
@@ -210,7 +205,7 @@ class DotHandler {
         device_mesh.dim(mesh_dim1) > 1) {
       std::string name =
           absl::StrFormat("SbSj = SbR x SbSj @ {%d,%d}", mesh_dim0, mesh_dim1);
-      HloSharding output_spec = Tile(ins->shape(), {0, space_base_dim + 1},
+      HloSharding output_spec = Tile(ins->shape(), {0, out_rhs_space_dim},
                                      {mesh_dim0, mesh_dim1}, device_mesh);
       HloSharding lhs_spec =
           Tile(lhs->shape(), {lhs_batch_dims[0]}, {mesh_dim0}, device_mesh);
@@ -277,7 +272,7 @@ class DotHandler {
       if (lhs->shape().dimensions(lhs_space_dims[0]) % num_devices == 0) {
         std::string name = absl::StrFormat("Si = Si x R @ %d", mesh_dim);
         HloSharding output_spec =
-            Tile(ins->shape(), {space_base_dim}, {mesh_dim}, device_mesh_1d);
+            Tile(ins->shape(), {out_lhs_space_dim}, {mesh_dim}, device_mesh_1d);
         HloSharding lhs_spec =
             Tile(lhs->shape(), {lhs_space_dims[0]}, {mesh_dim}, device_mesh_1d);
         HloSharding rhs_spec = HloSharding::Replicate();
@@ -421,12 +416,12 @@ class DotHandler {
 
   // Dimension information
   const DotDimensionNumbers& dot_dnums;
-  int64_t space_base_dim;
-  std::vector<int64_t> lhs_space_dims, rhs_space_dims;
   const tensorflow::protobuf::RepeatedField<int64_t>& lhs_con_dims;
   const tensorflow::protobuf::RepeatedField<int64_t>& rhs_con_dims;
   const tensorflow::protobuf::RepeatedField<int64_t>& lhs_batch_dims;
   const tensorflow::protobuf::RepeatedField<int64_t>& rhs_batch_dims;
+  std::vector<int64_t> lhs_space_dims, rhs_space_dims;
+  int64_t out_lhs_space_dim, out_rhs_space_dim;
 };
 
 // Register strategies for dot instructions.

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_util.h
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_util.h
@@ -360,6 +360,11 @@ void FixMixedMeshShapeResharding(HloInstruction* inst, int operand_num,
                                  const Array<int64_t>& device_mesh,
                                  ReshardingCache* resharding_cache);
 
+// Normalize the dimension number of dot.
+// After normalization, each operand always have one contracting dim and
+// one space dim. The number of batch dims is unrestricted.
+StatusOr<bool> NormalizeDotDimension(HloModule* module);
+
 /*
  * Gradient accumulation
  */

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_util.h
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_util.h
@@ -362,7 +362,9 @@ void FixMixedMeshShapeResharding(HloInstruction* inst, int operand_num,
 
 // Normalize the dimension number of dot.
 // After normalization, each operand always have one contracting dim and
-// one space dim. The number of batch dims is unrestricted.
+// one space dim. The number of batch dims is unrestricted. For example,
+// This normalizes dot.1: f32[128] = dot([128], [128, 64]) to
+//                 dot.1: f32[1, 128] = dot([1, 128], [128, 64])
 StatusOr<bool> NormalizeDotDimension(HloModule* module);
 
 /*


### PR DESCRIPTION
Auto-sharding pass assumes the dot always two spatial dimensions. The GEMV dot after simplification does not meet this requirement. This PR adds a pre-processing to fix these dot instructions