### PR TITLE
Use HloModule instead of XlaComputation for alpa compiler's interface

### DIFF
--- a/tensorflow/compiler/xla/python/BUILD
+++ b/tensorflow/compiler/xla/python/BUILD
@@ -620,6 +620,7 @@ cc_library(
         "//tensorflow/compiler/xla/service:platform_util",
         "//tensorflow/compiler/xla/service:pass_context",
         "//tensorflow/compiler/xla/service/gpu:gpu_cost_model",
+        "//tensorflow/compiler/xla/service/spmd:alpa_compiler",
         "//tensorflow/compiler/xla/service/spmd:grad_acc_rewrite",
         "//tensorflow/core:lib",
         "@com_google_absl//absl/hash",
@@ -681,7 +682,6 @@ pybind_extension(
         "//tensorflow/compiler/xla/pjrt/distributed",
         "//tensorflow/compiler/xla/pjrt/distributed:client",
         "//tensorflow/compiler/xla/pjrt/distributed:service",
-        "//tensorflow/compiler/xla/service/spmd:alpa_compilation",
         "//tensorflow/core:lib",
         # Do NOT remove this dependency. The XLA Python extension must not
         # depend on any part of TensorFlow at runtime, **including**

--- a/tensorflow/compiler/xla/python/xla.cc
+++ b/tensorflow/compiler/xla/python/xla.cc
@@ -54,7 +54,6 @@ limitations under the License.
 #include "tensorflow/compiler/xla/python/transfer_guard_lib.h"
 #include "tensorflow/compiler/xla/python/types.h"
 #include "tensorflow/compiler/xla/python/xla_compiler.h"
-#include "tensorflow/compiler/xla/service/spmd/alpa_compile.h"
 #include "tensorflow/compiler/xla/shape.h"
 #include "tensorflow/compiler/xla/shape_util.h"
 #include "tensorflow/compiler/xla/statusor.h"
@@ -534,20 +533,6 @@ PYBIND11_MODULE(xla_extension, m) {
   m.def("pprof_profile_to_json", &PprofProfileToJson,
         "Decodes an uncompressed pprof Profile protocol buffer into a JSON "
         "representation");
-
-  m.def("run_auto_sharding", 
-        [](const XlaComputation& computation, CompileOptions options) {
-          py::gil_scoped_release gil_release;
-          return spmd::RunAutoShardingPass(computation, options);
-        }, 
-        py::arg("computation"), py::arg("compile_options") = CompileOptions());
-  m.def("run_spmd_partitioner", 
-        [](const XlaComputation& computation, CompileOptions options) {
-          py::gil_scoped_release gil_release;
-          return spmd::RunSpmdPartitionerPass(computation, options);
-        }, 
-        py::arg("computation"), py::arg("compile_options") = CompileOptions());
-
 }  // NOLINT(readability/fn_size)
 
 }  // namespace xla

--- a/tensorflow/compiler/xla/python/xla_compiler.cc
+++ b/tensorflow/compiler/xla/python/xla_compiler.cc
@@ -505,6 +505,18 @@ void BuildXlaCompilerSubmodule(py::module& m) {
       .def("set_spmd_output_sharding", &HloModule::set_spmd_output_sharding)
       .def("set_spmd_parameters_shardings", &HloModule::set_spmd_parameters_shardings)
       .def("infer_spmd_shardings", &HloModule::infer_spmd_shardings)
+      .def("setup_alias", [](std::shared_ptr<HloModule> hlo_module,
+                             const std::vector<int64_t>& output_index,
+                             int64_t param_number,
+                             const std::vector<int64_t>& param_index) {
+            hlo_module->input_output_alias_config().SetUpAlias(
+               ShapeIndex(output_index.begin(), output_index.end()),
+               param_number,
+               ShapeIndex(param_index.begin(), param_index.end()));
+          })
+      .def("program_shape", [](const HloModule& hlo_module) {
+            return hlo_module.entry_computation_layout().ComputeProgramShape();
+          })
       .def("parameter_shapes", [](const HloModule& hlo_module) -> std::vector<Shape>{
             const auto params = hlo_module.entry_computation()->parameter_instructions();
             std::vector<Shape> ret(params.size());

--- a/tensorflow/compiler/xla/service/spmd/BUILD
+++ b/tensorflow/compiler/xla/service/spmd/BUILD
@@ -236,7 +236,7 @@ cc_library(
 )
 
 cc_library(
-    name = "alpa_compilation",
+    name = "alpa_compiler",
     srcs = ["alpa_compile.cc"],
     hdrs = ["alpa_compile.h"],
     deps = [

--- a/tensorflow/compiler/xla/service/spmd/alpa_compile.h
+++ b/tensorflow/compiler/xla/service/spmd/alpa_compile.h
@@ -6,13 +6,12 @@
 namespace xla {
 namespace spmd {
 
-// Compile an Xla Computation into HloModule, then apply Alpa's passes.
-// The result hlo is later compiled again to apply spmd and other optimizations.
-StatusOr<std::shared_ptr<HloModule>> RunAutoShardingPass(
-    const XlaComputation& computation, CompileOptions options);
+// Run the auto sharding pass to add sharding anotations
+// for each HLO instruction.
+Status RunAutoShardingPass(HloModule* hlo_module, const CompileOptions& options);
 
-StatusOr<std::shared_ptr<HloModule>> RunSpmdPartitionerPass(
-    const XlaComputation& computation, CompileOptions options);
+// Run the SPMD partitioner pass.
+Status RunSpmdPartitionerPass(HloModule* hlo_module, const CompileOptions& options);
 
 };  // namespace spmd
 };  // namespace xla


### PR DESCRIPTION
`HloModule` is more flexible than `XlaComputation`. This PR modifies most of alpa compiler's interfaces such as `run_auto_sharding_pass`, `run_spmd_partitioner_pass` and `slice_auto_sharded_stages` to take HloModule as input and return HloModule.