### PR TITLE
Add status/statusOr for Alpa NCCL apis to catch exception

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -45,7 +45,7 @@ Status ncclResultToStatus(ncclResult_t s, const char* file, int64_t line,
   if (s == ncclSuccess) {
     return Status::OK();
   }
-  return errors::Internal(
+  return tensorflow::errors::Internal(
       absl::StrFormat("%s:%d: NCCL operation %s failed: %s", file, line, expr,
                       ncclGetErrorString(s)));
 }

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -40,6 +40,16 @@ PYBIND11_MAKE_OPAQUE(std::vector<ncclComm_t>);
 namespace xla {
 namespace gpu {
 
+Status ncclResultToStatus(ncclResult_t s, const char* file, int64_t line,
+                          const char* expr) {
+  if (s == ncclSuccess) {
+    return Status::OK();
+  }
+  return tensorflow::errors::Internal(
+      absl::StrFormat("%s:%d: NCCL operation %s failed: %s", file, line, expr,
+                      ncclGetErrorString(s)));
+}
+
 ncclDataType_t ToNcclDataType(PrimitiveType element_type) {
   switch (element_type) {
     case S8:
@@ -91,117 +101,155 @@ int SizeOfType(ncclDataType_t element_type) {
   }
 }
 
-std::shared_ptr< std::vector<ncclComm_t> > NcclInitCommunicator(std::vector<int> devices_vec) {
+tensorflow::StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclInitCommunicator(std::vector<int> devices_vec) {
+#if XLA_ENABLE_XCCL
     int n_devices = devices_vec.size();
     std::vector<ncclComm_t> comms;
     comms.resize(n_devices);
-    ncclCommInitAll(comms.data(), n_devices, devices_vec.data());
+    XLA_CUDA_RETURN_IF_ERROR(ncclCommInitAll(comms.data(), n_devices, devices_vec.data()));
     return std::make_shared< std::vector<ncclComm_t> >(std::move(comms));
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
 }
 
-void NcclLocalAllGather(std::vector<ncclComm_t> comms, 
-                        std::vector<PyBuffer::object> buffers, 
-                        std::vector<uint> local_start_positions, // TODO(hexu): is the range of uint too small?
-                        uint global_start, 
-                        uint n_elements) {
+tensorflow::Status NcclLocalAllGather(std::vector<ncclComm_t> comms, 
+                                      std::vector<PyBuffer::object> buffers, 
+                                      std::vector<uint> local_start_positions, // TODO(hexu): is the range of uint too small?
+                                      uint global_start, 
+                                      uint n_elements) {
+#if XLA_ENABLE_XCCL
   int n_devices = comms.size();
   CHECK_EQ(n_devices, buffers.size());
   CHECK_EQ(n_devices, local_start_positions.size());
 
   ncclDataType_t dtype = ToNcclDataType(buffers[0].buf()->buffer()->on_device_shape().element_type());
   int dtype_size = SizeOfType(dtype);
-  ncclGroupStart();
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
   for (int i = 0; i < n_devices; ++i) {
     std::uintptr_t sendbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
     sendbuff = sendbuff + local_start_positions[i]*dtype_size;
     std::uintptr_t recvbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
     recvbuff = recvbuff + global_start*dtype_size;
-    ncclAllGather((void*)sendbuff, (void*)recvbuff, n_elements, dtype, comms[i], cudaStreamLegacy);
+    XLA_CUDA_RETURN_IF_ERROR(ncclAllGather((void*)sendbuff, (void*)recvbuff, n_elements, dtype, comms[i], cudaStreamLegacy));
   }
-  ncclGroupEnd();
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
+  return Status::OK();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
 }
 
 
-void NcclDestroyComms(std::vector<ncclComm_t> comms) {
+tensorflow::Status NcclDestroyComms(std::vector<ncclComm_t> comms) {
+#if XLA_ENABLE_XCCL
   for (auto comm : comms) 
-    ncclCommDestroy(comm);
+    XLA_CUDA_RETURN_IF_ERROR(ncclCommDestroy(comm));
+  return Status::OK();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
 }
 
-void NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms, 
-                              std::vector<PyBuffer::object> buffers, 
-                              std::vector<uint> local_start_positions, 
-                              uint n_elements, 
-                              int root_rank) {
+tensorflow::Status NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms, 
+                                            std::vector<PyBuffer::object> buffers, 
+                                            std::vector<uint> local_start_positions, 
+                                            uint n_elements, 
+                                            int root_rank) {
+#if XLA_ENABLE_XCCL
   int n_devices = comms.size();
   CHECK_EQ(n_devices, buffers.size());
   CHECK_EQ(n_devices, local_start_positions.size());
 
   ncclDataType_t dtype = ToNcclDataType(buffers[0].buf()->buffer()->on_device_shape().element_type());
   int dtype_size = SizeOfType(dtype);
-  ncclGroupStart();
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
   for (int i = 0; i < n_devices; ++i) {
     std::uintptr_t sendbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
     sendbuff = sendbuff + local_start_positions[i]*dtype_size;
     std::uintptr_t recvbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
     recvbuff = recvbuff + local_start_positions[i]*dtype_size;
-    ncclBroadcast((void*)sendbuff, (void*)recvbuff, n_elements, dtype, root_rank, comms[i], cudaStreamLegacy);
+    XLA_CUDA_RETURN_IF_ERROR(ncclBroadcast((void*)sendbuff, (void*)recvbuff, n_elements, dtype, root_rank, comms[i], cudaStreamLegacy));
   }
-  ncclGroupEnd();
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
+  return Status::OK();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
 }
 
-void NcclSend(std::vector<ncclComm_t> comms,
-              PyBuffer::object buffer,
-              uint start,
-              uint n_elements,
-              int peer_p2p_rank) {
+tensorflow::Status NcclSend(std::vector<ncclComm_t> comms,
+                            PyBuffer::object buffer,
+                            uint start,
+                            uint n_elements,
+                            int peer_p2p_rank) {
+#if XLA_ENABLE_XCCL
   ncclDataType_t dtype = ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type());
   int dtype_size = SizeOfType(dtype);
   std::uintptr_t sendbuff = buffer.buf()->UnsafeBufferPointer().ValueOrDie();
   sendbuff = sendbuff + start*dtype_size;
-  ncclSend((void*)sendbuff, n_elements, dtype, peer_p2p_rank, comms[0], cudaStreamLegacy);
+  XLA_CUDA_RETURN_IF_ERROR(ncclSend((void*)sendbuff, n_elements, dtype, peer_p2p_rank, comms[0], cudaStreamLegacy));
+  return Status::OK();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
 }
 
-void NcclRecv(std::vector<ncclComm_t> comms,
-              PyBuffer::object buffer,
-              uint start,
-              uint n_elements,
-              int peer_p2p_rank) {
+tensorflow::Status NcclRecv(std::vector<ncclComm_t> comms,
+                            PyBuffer::object buffer,
+                            uint start,
+                            uint n_elements,
+                            int peer_p2p_rank) {
+#if XLA_ENABLE_XCCL
   ncclDataType_t dtype = ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type());
   int dtype_size = SizeOfType(dtype);
   std::uintptr_t recvbuff = buffer.buf()->UnsafeBufferPointer().ValueOrDie();
   recvbuff = recvbuff + start*dtype_size;
-  ncclRecv((void*)recvbuff, n_elements, dtype, peer_p2p_rank, comms[0], cudaStreamLegacy);
+  XLA_CUDA_RETURN_IF_ERROR(ncclRecv((void*)recvbuff, n_elements, dtype, peer_p2p_rank, comms[0], cudaStreamLegacy));
+  return Status::OK();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
 }
 
 std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid) {
-  std::vector<char> nccl_uid_vec(128, 0);
-  memcpy(nccl_uid_vec.data(), &nccl_uid, sizeof(nccl_uid));
+  std::vector<char> nccl_uid_vec(sizeof(nccl_uid.internal), 0);
+  memcpy(nccl_uid_vec.data(), &nccl_uid.internal, sizeof(nccl_uid));
   return nccl_uid_vec;
 }
 
 ncclUniqueId NcclUidDeserialize(std::vector<char> nccl_uid_vec) {
   ncclUniqueId nccl_uid;
-  memcpy(&nccl_uid, nccl_uid_vec.data(), sizeof(nccl_uid));
+  memcpy(&nccl_uid.internal, nccl_uid_vec.data(), sizeof(nccl_uid));
   return nccl_uid;
 }
 
-std::vector<char> NcclGetUniqueId() {
+tensorflow::StatusOr< std::vector<char> > NcclGetUniqueId() {
+#if XLA_ENABLE_XCCL
   ncclUniqueId id;
-  ncclGetUniqueId(&id);
+  XLA_CUDA_RETURN_IF_ERROR(ncclGetUniqueId(&id));
   std::vector<char> nccl_uid_vec = NcclUidSerialize(id);
   return nccl_uid_vec;
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
 }
 
-int NcclGetVersion() {
+tensorflow::StatusOr<int> NcclGetVersion() {
+#if XLA_ENABLE_XCCL
   int version;
-  ncclGetVersion(&version);
+  XLA_CUDA_RETURN_IF_ERROR(ncclGetVersion(&version));
   return version;
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
 }
 
-std::shared_ptr< std::vector<ncclComm_t> > NcclCreateCommunicators(int world_size, 
-                                                                   std::vector<int> devices_global_rank, 
-                                                                   std::vector<int> devices_ids, 
-                                                                   std::vector<char> nccl_uid_vec) {
+tensorflow::StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclCreateCommunicators(int world_size, 
+                                                                                           std::vector<int> devices_global_rank, 
+                                                                                           std::vector<int> devices_ids, 
+                                                                                           std::vector<char> nccl_uid_vec) {
+#if XLA_ENABLE_XCCL
   int n_devices = devices_global_rank.size();
   CHECK_EQ(n_devices, devices_ids.size());
   CHECK_EQ(128, nccl_uid_vec.size());
@@ -209,16 +257,19 @@ std::shared_ptr< std::vector<ncclComm_t> > NcclCreateCommunicators(int world_siz
   ncclUniqueId nccl_uid = NcclUidDeserialize(nccl_uid_vec);
   std::vector<ncclComm_t> comms;
   comms.resize(n_devices);
-  ncclGroupStart();
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
   for (int i=0; i<n_devices; i++) {
     cudaSetDevice(devices_ids[i]);
-    ncclCommInitRank(comms.data()+i, world_size, nccl_uid, devices_global_rank[i]);
+    XLA_CUDA_RETURN_IF_ERROR(ncclCommInitRank(comms.data()+i, world_size, nccl_uid, devices_global_rank[i]));
   }
-  ncclGroupEnd();
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
   return std::make_shared< std::vector<ncclComm_t> >(std::move(comms));
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
 }
 
-int GetBufferDeviceId(PyBuffer::object buffer) {
+tensorflow::StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer) {
   return buffer.buf()->device()->local_hardware_id();
 }
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -214,13 +214,14 @@ tensorflow::Status NcclRecv(std::vector<ncclComm_t> comms,
 
 std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid) {
   std::vector<char> nccl_uid_vec(sizeof(nccl_uid.internal), 0);
-  memcpy(nccl_uid_vec.data(), &nccl_uid.internal, sizeof(nccl_uid));
+  memcpy(nccl_uid_vec.data(), &nccl_uid.internal, sizeof(nccl_uid.internal));
   return nccl_uid_vec;
 }
 
 ncclUniqueId NcclUidDeserialize(std::vector<char> nccl_uid_vec) {
   ncclUniqueId nccl_uid;
-  memcpy(&nccl_uid.internal, nccl_uid_vec.data(), sizeof(nccl_uid));
+  CHECK_EQ(sizeof(nccl_uid.internal), nccl_uid_vec.size());
+  memcpy(&nccl_uid.internal, nccl_uid_vec.data(), sizeof(nccl_uid.internal));
   return nccl_uid;
 }
 
@@ -252,7 +253,6 @@ tensorflow::StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclCreateCom
 #if XLA_ENABLE_XCCL
   int n_devices = devices_global_rank.size();
   CHECK_EQ(n_devices, devices_ids.size());
-  CHECK_EQ(128, nccl_uid_vec.size());
 
   ncclUniqueId nccl_uid = NcclUidDeserialize(nccl_uid_vec);
   std::vector<ncclComm_t> comms;

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -45,7 +45,7 @@ Status ncclResultToStatus(ncclResult_t s, const char* file, int64_t line,
   if (s == ncclSuccess) {
     return Status::OK();
   }
-  return tensorflow::errors::Internal(
+  return errors::Internal(
       absl::StrFormat("%s:%d: NCCL operation %s failed: %s", file, line, expr,
                       ncclGetErrorString(s)));
 }
@@ -101,7 +101,7 @@ int SizeOfType(ncclDataType_t element_type) {
   }
 }
 
-tensorflow::StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclInitCommunicator(std::vector<int> devices_vec) {
+StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclInitCommunicator(std::vector<int> devices_vec) {
 #if XLA_ENABLE_XCCL
     int n_devices = devices_vec.size();
     std::vector<ncclComm_t> comms;
@@ -113,11 +113,11 @@ tensorflow::StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclInitCommu
 #endif  // XLA_ENABLE_XCCL
 }
 
-tensorflow::Status NcclLocalAllGather(std::vector<ncclComm_t> comms, 
-                                      std::vector<PyBuffer::object> buffers, 
-                                      std::vector<uint> local_start_positions, // TODO(hexu): is the range of uint too small?
-                                      uint global_start, 
-                                      uint n_elements) {
+Status NcclLocalAllGather(std::vector<ncclComm_t> comms, 
+                          std::vector<PyBuffer::object> buffers, 
+                          std::vector<uint> local_start_positions, // TODO(hexu): is the range of uint too small?
+                          uint global_start, 
+                          uint n_elements) {
 #if XLA_ENABLE_XCCL
   int n_devices = comms.size();
   CHECK_EQ(n_devices, buffers.size());
@@ -141,7 +141,7 @@ tensorflow::Status NcclLocalAllGather(std::vector<ncclComm_t> comms,
 }
 
 
-tensorflow::Status NcclDestroyComms(std::vector<ncclComm_t> comms) {
+Status NcclDestroyComms(std::vector<ncclComm_t> comms) {
 #if XLA_ENABLE_XCCL
   for (auto comm : comms) 
     XLA_CUDA_RETURN_IF_ERROR(ncclCommDestroy(comm));
@@ -151,11 +151,11 @@ tensorflow::Status NcclDestroyComms(std::vector<ncclComm_t> comms) {
 #endif  // XLA_ENABLE_XCCL
 }
 
-tensorflow::Status NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms, 
-                                            std::vector<PyBuffer::object> buffers, 
-                                            std::vector<uint> local_start_positions, 
-                                            uint n_elements, 
-                                            int root_rank) {
+Status NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms, 
+                                std::vector<PyBuffer::object> buffers, 
+                                std::vector<uint> local_start_positions, 
+                                uint n_elements, 
+                                int root_rank) {
 #if XLA_ENABLE_XCCL
   int n_devices = comms.size();
   CHECK_EQ(n_devices, buffers.size());
@@ -178,11 +178,11 @@ tensorflow::Status NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms,
 #endif  // XLA_ENABLE_XCCL
 }
 
-tensorflow::Status NcclSend(std::vector<ncclComm_t> comms,
-                            PyBuffer::object buffer,
-                            uint start,
-                            uint n_elements,
-                            int peer_p2p_rank) {
+Status NcclSend(std::vector<ncclComm_t> comms,
+                PyBuffer::object buffer,
+                uint start,
+                uint n_elements,
+                int peer_p2p_rank) {
 #if XLA_ENABLE_XCCL
   ncclDataType_t dtype = ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type());
   int dtype_size = SizeOfType(dtype);
@@ -195,11 +195,11 @@ tensorflow::Status NcclSend(std::vector<ncclComm_t> comms,
 #endif  // XLA_ENABLE_XCCL
 }
 
-tensorflow::Status NcclRecv(std::vector<ncclComm_t> comms,
-                            PyBuffer::object buffer,
-                            uint start,
-                            uint n_elements,
-                            int peer_p2p_rank) {
+Status NcclRecv(std::vector<ncclComm_t> comms,
+                PyBuffer::object buffer,
+                uint start,
+                uint n_elements,
+                int peer_p2p_rank) {
 #if XLA_ENABLE_XCCL
   ncclDataType_t dtype = ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type());
   int dtype_size = SizeOfType(dtype);
@@ -225,7 +225,7 @@ ncclUniqueId NcclUidDeserialize(std::vector<char> nccl_uid_vec) {
   return nccl_uid;
 }
 
-tensorflow::StatusOr< std::vector<char> > NcclGetUniqueId() {
+StatusOr< std::vector<char> > NcclGetUniqueId() {
 #if XLA_ENABLE_XCCL
   ncclUniqueId id;
   XLA_CUDA_RETURN_IF_ERROR(ncclGetUniqueId(&id));
@@ -236,7 +236,7 @@ tensorflow::StatusOr< std::vector<char> > NcclGetUniqueId() {
 #endif  // XLA_ENABLE_XCCL
 }
 
-tensorflow::StatusOr<int> NcclGetVersion() {
+StatusOr<int> NcclGetVersion() {
 #if XLA_ENABLE_XCCL
   int version;
   XLA_CUDA_RETURN_IF_ERROR(ncclGetVersion(&version));
@@ -246,10 +246,10 @@ tensorflow::StatusOr<int> NcclGetVersion() {
 #endif  // XLA_ENABLE_XCCL
 }
 
-tensorflow::StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclCreateCommunicators(int world_size, 
-                                                                                           std::vector<int> devices_global_rank, 
-                                                                                           std::vector<int> devices_ids, 
-                                                                                           std::vector<char> nccl_uid_vec) {
+StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclCreateCommunicators(int world_size, 
+                                                                               std::vector<int> devices_global_rank, 
+                                                                               std::vector<int> devices_ids, 
+                                                                               std::vector<char> nccl_uid_vec) {
 #if XLA_ENABLE_XCCL
   int n_devices = devices_global_rank.size();
   CHECK_EQ(n_devices, devices_ids.size());
@@ -269,7 +269,7 @@ tensorflow::StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclCreateCom
 #endif  // XLA_ENABLE_XCCL
 }
 
-tensorflow::StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer) {
+StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer) {
   return buffer.buf()->device()->local_hardware_id();
 }
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -70,48 +70,48 @@ ncclDataType_t ToNcclDataType(PrimitiveType element_type);
 
 int SizeOfType(ncclDataType_t element_type);
 
-tensorflow::StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclInitCommunicator(std::vector<int> devices_vec);
+StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclInitCommunicator(std::vector<int> devices_vec);
 
-tensorflow::Status NcclLocalAllGather(std::vector<ncclComm_t> comms, 
-                                      std::vector<PyBuffer::object> buffers, 
-                                      std::vector<uint> local_start_positions, 
-                                      uint global_start, 
-                                      uint n_elements);
+Status NcclLocalAllGather(std::vector<ncclComm_t> comms, 
+                          std::vector<PyBuffer::object> buffers, 
+                          std::vector<uint> local_start_positions, 
+                          uint global_start, 
+                          uint n_elements);
 
-tensorflow::Status NcclDestroyComms(std::vector<ncclComm_t> comms);
+Status NcclDestroyComms(std::vector<ncclComm_t> comms);
 
-tensorflow::Status NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms, 
-                                            std::vector<PyBuffer::object> buffers, 
-                                            std::vector<uint> local_start_positions, 
-                                            uint n_elements, 
-                                            int root_rank);
+Status NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms, 
+                                std::vector<PyBuffer::object> buffers, 
+                                std::vector<uint> local_start_positions, 
+                                uint n_elements, 
+                                int root_rank);
 
-tensorflow::Status NcclSend(std::vector<ncclComm_t> comms, 
-                            PyBuffer::object buffer, 
-                            uint start, 
-                            uint n_elements, 
-                            int peer_p2p_rank);
+Status NcclSend(std::vector<ncclComm_t> comms, 
+                PyBuffer::object buffer, 
+                uint start, 
+                uint n_elements, 
+                int peer_p2p_rank);
 
-tensorflow::Status NcclRecv(std::vector<ncclComm_t> comms,
-                            PyBuffer::object buffer,
-                            uint start,
-                            uint n_elements,
-                            int peer_p2p_rank);
+Status NcclRecv(std::vector<ncclComm_t> comms,
+                PyBuffer::object buffer,
+                uint start,
+                uint n_elements,
+                int peer_p2p_rank);
 
 std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid);
 
 ncclUniqueId NcclUidDeserialize(std::vector<char> nccl_uid_chars);
 
-tensorflow::StatusOr< std::vector<char> > NcclGetUniqueId();
+StatusOr< std::vector<char> > NcclGetUniqueId();
 
-tensorflow::StatusOr<int> NcclGetVersion();
+StatusOr<int> NcclGetVersion();
 
-tensorflow::StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclCreateCommunicators(int world_size,
-                                                                                           std::vector<int> devices_global_rank,
-                                                                                           std::vector<int> devices_ids,
-                                                                                           std::vector<char> nccl_uid);
+StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclCreateCommunicators(int world_size,
+                                                                               std::vector<int> devices_global_rank,
+                                                                               std::vector<int> devices_ids,
+                                                                               std::vector<char> nccl_uid);
 
-tensorflow::StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer);
+StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer);
 
 
 }  // namespace gpu


### PR DESCRIPTION
This PR follows [[Feature]Deprecate cupy nccl api and change to use nccl imported from tensorflow-alpa #116](https://github.com/alpa-projects/tensorflow-alpa/pull/116). 

1. Add status/statusOr for Alpa NCCL apis to catch exception.
2. Replace the 128 constant by sizeof(nccl_uid.internal) and related code.