### PR TITLE
Bypass cudaStreamLegacy related bug that exists in early version of NCCL

### DIFF
--- a/tensorflow/compiler/xla/python/xla.cc
+++ b/tensorflow/compiler/xla/python/xla.cc
@@ -538,21 +538,22 @@ PYBIND11_MODULE(xla_extension, m) {
         "Decodes an uncompressed pprof Profile protocol buffer into a JSON "
         "representation");
 
-  py::class_<std::vector<ncclComm_t>, std::shared_ptr<std::vector<ncclComm_t>>> ncclComm_vec(m, "ncclComm_vec");
+  py::class_<gpu::collectiveStorage, std::shared_ptr<gpu::collectiveStorage>> collective_storage(m, "collective_storage");
+  // py::class_<std::vector<ncclComm_t>, std::shared_ptr<std::vector<ncclComm_t>>> ncclComm_vec(m, "ncclComm_vec");
   m.def("nccl_init_communicator", &gpu::NcclInitCommunicator,
         "Initialize single thread communicators");
   m.def("nccl_local_all_gather", &gpu::NcclLocalAllGather, "nccl local allgather");
-  m.def("nccl_destroy_comms", &gpu::NcclDestroyComms, "destroy comms");
+  // m.def("nccl_destroy_comms", &gpu::NcclDestroyComms, "destroy comms");
   m.def("nccl_get_unique_id", &gpu::NcclGetUniqueId, "get unique nccl id");
   m.def("nccl_get_version", &gpu::NcclGetVersion, "get nccl version");
-  m.def("nccl_broadcast_partial_gpus", &gpu::NcclBroadcastPartialGPUs,
-        "nccl broadcast with only a subset of gpus in the host are involved");
-  m.def("nccl_create_communicators", &gpu::NcclCreateCommunicators, 
-        "nccl create communicators for multiple threads case");
+  // m.def("nccl_broadcast_partial_gpus", &gpu::NcclBroadcastPartialGPUs,
+  //       "nccl broadcast with only a subset of gpus in the host are involved");
+  // m.def("nccl_create_communicators", &gpu::NcclCreateCommunicators, 
+  //       "nccl create communicators for multiple threads case");
   m.def("get_buffer_device_id", &gpu::GetBufferDeviceId, 
         "get the local device id for one pybuffer");
-  m.def("nccl_recv", &gpu::NcclRecv, "nccl recv data");
-  m.def("nccl_send", &gpu::NcclSend, "nccl send data");
+  // m.def("nccl_recv", &gpu::NcclRecv, "nccl recv data");
+  // m.def("nccl_send", &gpu::NcclSend, "nccl send data");
 
 }  // NOLINT(readability/fn_size)
 

--- a/tensorflow/compiler/xla/python/xla.cc
+++ b/tensorflow/compiler/xla/python/xla.cc
@@ -538,7 +538,9 @@ PYBIND11_MODULE(xla_extension, m) {
         "Decodes an uncompressed pprof Profile protocol buffer into a JSON "
         "representation");
 
-  py::class_<gpu::collectiveStorage, std::shared_ptr<gpu::collectiveStorage>> collective_storage(m, "collective_storage");
+  py::class_<gpu::NcclCommStorage,
+             std::shared_ptr<gpu::NcclCommStorage>>
+      nccl_comm_storage(m, "nccl_comm_storage");
   m.def("nccl_init_communicator", &gpu::NcclInitCommunicator,
         "Initialize single thread communicators");
   m.def("nccl_local_all_gather", &gpu::NcclLocalAllGather, "nccl local allgather");

--- a/tensorflow/compiler/xla/python/xla.cc
+++ b/tensorflow/compiler/xla/python/xla.cc
@@ -539,21 +539,20 @@ PYBIND11_MODULE(xla_extension, m) {
         "representation");
 
   py::class_<gpu::collectiveStorage, std::shared_ptr<gpu::collectiveStorage>> collective_storage(m, "collective_storage");
-  // py::class_<std::vector<ncclComm_t>, std::shared_ptr<std::vector<ncclComm_t>>> ncclComm_vec(m, "ncclComm_vec");
   m.def("nccl_init_communicator", &gpu::NcclInitCommunicator,
         "Initialize single thread communicators");
   m.def("nccl_local_all_gather", &gpu::NcclLocalAllGather, "nccl local allgather");
-  // m.def("nccl_destroy_comms", &gpu::NcclDestroyComms, "destroy comms");
+  m.def("nccl_destroy_comms", &gpu::NcclDestroyComms, "destroy comms");
   m.def("nccl_get_unique_id", &gpu::NcclGetUniqueId, "get unique nccl id");
   m.def("nccl_get_version", &gpu::NcclGetVersion, "get nccl version");
-  // m.def("nccl_broadcast_partial_gpus", &gpu::NcclBroadcastPartialGPUs,
-  //       "nccl broadcast with only a subset of gpus in the host are involved");
-  // m.def("nccl_create_communicators", &gpu::NcclCreateCommunicators, 
-  //       "nccl create communicators for multiple threads case");
+  m.def("nccl_broadcast_partial_gpus", &gpu::NcclBroadcastPartialGPUs,
+        "nccl broadcast with only a subset of gpus in the host are involved");
+  m.def("nccl_create_communicators", &gpu::NcclCreateCommunicators, 
+        "nccl create communicators for multiple threads case");
   m.def("get_buffer_device_id", &gpu::GetBufferDeviceId, 
         "get the local device id for one pybuffer");
-  // m.def("nccl_recv", &gpu::NcclRecv, "nccl recv data");
-  // m.def("nccl_send", &gpu::NcclSend, "nccl send data");
+  m.def("nccl_recv", &gpu::NcclRecv, "nccl recv data");
+  m.def("nccl_send", &gpu::NcclSend, "nccl send data");
 
 }  // NOLINT(readability/fn_size)
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -113,9 +113,7 @@ StatusOr< std::shared_ptr<NcclCommStorage> > NcclInitCommunicator(std::vector<in
     streams.resize(n_devices);
     for (int i = 0; i < n_devices; ++i) {
       cudaSetDevice(devices_vec[i]);
-      // cudaStreamCreateWithFlags(streams.data()+i, cudaStreamDefault);
       cudaStreamCreate(streams.data()+i);
-      std::cout<<streams[i]<<" initcomm"<<std::endl;
     }
     NcclCommStorage storage;
     storage.comms = comms;
@@ -145,17 +143,11 @@ Status NcclLocalAllGather(const NcclCommStorage &storage,
     sendbuff = sendbuff + local_start_positions[i]*dtype_size;
     std::uintptr_t recvbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
     recvbuff = recvbuff + global_start*dtype_size;
-    std::cout<<storage.streams[i]<<" allgather"<<std::endl;
     XLA_CUDA_RETURN_IF_ERROR(ncclAllGather((void*)sendbuff, (void*)recvbuff, n_elements, dtype, storage.comms[i], storage.streams[i]));
-    // XLA_CUDA_RETURN_IF_ERROR(ncclAllGather((void*)sendbuff, (void*)recvbuff, n_elements, dtype, storage.comms[i], cudaStreamLegacy));
   }
   XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
 
-  for (int i = 0; i < n_devices; ++i) {
-    // int device_id = GetBufferDeviceId(buffers[i]);
-    // cudaSetDevice(device_id);
-    cudaStreamSynchronize(storage.streams[i]);
-  }
+  for (int i = 0; i < n_devices; ++i) cudaStreamSynchronize(storage.streams[i]);
   return Status::OK();
 #else   // XLA_ENABLE_XCCL
   return Unimplemented("NCCL support is not available.");
@@ -192,16 +184,10 @@ Status NcclBroadcastPartialGPUs(const NcclCommStorage &storage,
     std::uintptr_t recvbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
     recvbuff = recvbuff + local_start_positions[i]*dtype_size;
     XLA_CUDA_RETURN_IF_ERROR(ncclBroadcast((void*)sendbuff, (void*)recvbuff, n_elements, dtype, root_rank, storage.comms[i], storage.streams[i]));
-    // XLA_CUDA_RETURN_IF_ERROR(ncclBroadcast((void*)sendbuff, (void*)recvbuff, n_elements, dtype, root_rank, storage.comms[i], cudaStreamLegacy));
   }
   XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
 
-  for (int i = 0; i < n_devices; ++i) {
-    // int device_id = GetBufferDeviceId(buffers[i]);
-    // cudaSetDevice(device_id);
-    cudaStreamSynchronize(storage.streams[i]);
-  }
-
+  for (int i = 0; i < n_devices; ++i) cudaStreamSynchronize(storage.streams[i]);
   return Status::OK();
 #else   // XLA_ENABLE_XCCL
   return Unimplemented("NCCL support is not available.");
@@ -218,9 +204,7 @@ Status NcclSend(const NcclCommStorage &storage,
   int dtype_size = SizeOfType(dtype);
   std::uintptr_t sendbuff = buffer.buf()->UnsafeBufferPointer().ValueOrDie();
   sendbuff = sendbuff + start*dtype_size;
-  std::cout<<storage.streams[0]<<" send"<<std::endl;
   XLA_CUDA_RETURN_IF_ERROR(ncclSend((void*)sendbuff, n_elements, dtype, peer_p2p_rank, storage.comms[0], storage.streams[0]));
-  // XLA_CUDA_RETURN_IF_ERROR(ncclSend((void*)sendbuff, n_elements, dtype, peer_p2p_rank, storage.comms[0], cudaStreamLegacy));
   cudaStreamSynchronize(storage.streams[0]);
   return Status::OK();
 #else   // XLA_ENABLE_XCCL
@@ -238,9 +222,7 @@ Status NcclRecv(const NcclCommStorage &storage,
   int dtype_size = SizeOfType(dtype);
   std::uintptr_t recvbuff = buffer.buf()->UnsafeBufferPointer().ValueOrDie();
   recvbuff = recvbuff + start*dtype_size;
-  std::cout<<storage.streams[0]<<" recv"<<std::endl;
   XLA_CUDA_RETURN_IF_ERROR(ncclRecv((void*)recvbuff, n_elements, dtype, peer_p2p_rank, storage.comms[0], storage.streams[0]));
-  // XLA_CUDA_RETURN_IF_ERROR(ncclRecv((void*)recvbuff, n_elements, dtype, peer_p2p_rank, storage.comms[0], cudaStreamLegacy));
   cudaStreamSynchronize(storage.streams[0]);
   return Status::OK();
 #else   // XLA_ENABLE_XCCL
@@ -304,9 +286,7 @@ StatusOr< std::shared_ptr<NcclCommStorage> > NcclCreateCommunicators(int world_s
   streams.resize(n_devices);
   for (int i=0; i<n_devices; i++) {
     cudaSetDevice(devices_ids[i]);
-    // cudaStreamCreateWithFlags(streams.data()+i, cudaStreamDefault);
     cudaStreamCreate(streams.data()+i);
-    std::cout<<streams[i]<<" NcclCreateCommunicators"<<std::endl;
   }
 
   NcclCommStorage storage;

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -116,7 +116,8 @@ StatusOr< std::shared_ptr<collectiveStorage> > NcclInitCommunicator(std::vector<
     streams.resize(n_devices);
     for (int i = 0; i < n_devices; ++i) {
       cudaSetDevice(devices_vec[i]);
-      cudaStreamCreate(streams.data()+i);
+      // cudaStreamCreate(streams.data()+i);
+      cudaStreamCreateWithFlags(streams.data()+i, cudaStreamDefault);
     }
     collectiveStorage storage;
     storage.comms = comms;
@@ -127,49 +128,7 @@ StatusOr< std::shared_ptr<collectiveStorage> > NcclInitCommunicator(std::vector<
 #endif  // XLA_ENABLE_XCCL
 }
 
-// StatusOr< std::shared_ptr<std::vector<collectiveStorage>> > NcclInitCommunicator(std::vector<int> devices_vec) {
-// #if XLA_ENABLE_XCCL
-//     int n_devices = devices_vec.size();
-//     std::vector<ncclComm_t> comms;
-//     comms.resize(n_devices);
-//     XLA_CUDA_RETURN_IF_ERROR(ncclCommInitAll(comms.data(), n_devices, devices_vec.data()));
-
-//     std::vector<cudaStream_t> streams;
-//     streams.resize(n_devices);
-//     for (int i = 0; i < n_devices; ++i) {
-//       cudaSetDevice(devices_vec[i]);
-//       cudaStreamCreate(streams.data()+i);
-//     }
-//     std::vector<collectiveStorage> storages;
-//     for (int i = 0; i < n_devices; ++i) storages.push_back(collectiveStorage(comms[i], streams[i]));
-
-//     return std::make_shared<std::vector<collectiveStorage>>(std::move(storages));
-// #else   // XLA_ENABLE_XCCL
-//   return Unimplemented("NCCL support is not available.");
-// #endif  // XLA_ENABLE_XCCL
-// }
-
-// StatusOr< std::tuple<std::shared_ptr<std::vector<ncclComm_t>>, std::shared_ptr<std::vector<cudaStream_t>>>> NcclInitCommunicator(std::vector<int> devices_vec) {
-// #if XLA_ENABLE_XCCL
-//     int n_devices = devices_vec.size();
-//     std::vector<ncclComm_t> comms;
-//     comms.resize(n_devices);
-//     XLA_CUDA_RETURN_IF_ERROR(ncclCommInitAll(comms.data(), n_devices, devices_vec.data()));
-
-//     std::vector<cudaStream_t> streams;
-//     streams.resize(n_devices);
-//     for (int i = 0; i < n_devices; ++i) {
-//       cudaSetDevice(devices_vec[i]);
-//       cudaStreamCreate(streams.data()+i);
-//     }
-
-//     return std::make_tuple(std::make_shared<std::vector<ncclComm_t>>(std::move(comms)), std::make_shared<std::vector<cudaStream_t>>(std::move(streams)));
-// #else   // XLA_ENABLE_XCCL
-//   return Unimplemented("NCCL support is not available.");
-// #endif  // XLA_ENABLE_XCCL
-// }
-
-Status NcclLocalAllGather(collectiveStorage storage,
+Status NcclLocalAllGather(const collectiveStorage &storage,
                           std::vector<PyBuffer::object> buffers,
                           std::vector<uint> local_start_positions, // TODO(hexu): is the range of uint too small?
                           uint global_start, 
@@ -197,81 +156,77 @@ Status NcclLocalAllGather(collectiveStorage storage,
 #endif  // XLA_ENABLE_XCCL
 }
 
+Status NcclDestroyComms(collectiveStorage &storage) {
+#if XLA_ENABLE_XCCL
+  for (auto comm : storage.comms) 
+    XLA_CUDA_RETURN_IF_ERROR(ncclCommDestroy(comm));
+  return Status::OK();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
 
-// Status NcclDestroyComms(std::vector<ncclComm_t> comms) {
-// #if XLA_ENABLE_XCCL
-//   for (auto comm : comms) 
-//     XLA_CUDA_RETURN_IF_ERROR(ncclCommDestroy(comm));
-//   return Status::OK();
-// #else   // XLA_ENABLE_XCCL
-//   return Unimplemented("NCCL support is not available.");
-// #endif  // XLA_ENABLE_XCCL
-// }
+Status NcclBroadcastPartialGPUs(const collectiveStorage &storage,
+                                std::vector<PyBuffer::object> buffers,
+                                std::vector<uint> local_start_positions,
+                                uint n_elements,
+                                int root_rank) {
+#if XLA_ENABLE_XCCL
+  int n_devices = storage.comms.size();
+  CHECK_EQ(n_devices, buffers.size());
+  CHECK_EQ(n_devices, local_start_positions.size());
+  CHECK_EQ(n_devices, storage.streams.size());
 
-// Status NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms, 
-//                                 std::vector<cudaStream_t> streams, 
-//                                 std::vector<PyBuffer::object> buffers, 
-//                                 std::vector<uint> local_start_positions, 
-//                                 uint n_elements, 
-//                                 int root_rank) {
-// #if XLA_ENABLE_XCCL
-//   int n_devices = comms.size();
-//   CHECK_EQ(n_devices, buffers.size());
-//   CHECK_EQ(n_devices, local_start_positions.size());
-//   CHECK_EQ(n_devices, streams.size());
+  ncclDataType_t dtype = ToNcclDataType(buffers[0].buf()->buffer()->on_device_shape().element_type());
+  int dtype_size = SizeOfType(dtype);
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
+  for (int i = 0; i < n_devices; ++i) {
+    std::uintptr_t sendbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
+    sendbuff = sendbuff + local_start_positions[i]*dtype_size;
+    std::uintptr_t recvbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
+    recvbuff = recvbuff + local_start_positions[i]*dtype_size;
+    XLA_CUDA_RETURN_IF_ERROR(ncclBroadcast((void*)sendbuff, (void*)recvbuff, n_elements, dtype, root_rank, storage.comms[i], storage.streams[i]));
+  }
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
+  return Status::OK();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
 
-//   ncclDataType_t dtype = ToNcclDataType(buffers[0].buf()->buffer()->on_device_shape().element_type());
-//   int dtype_size = SizeOfType(dtype);
-//   XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
-//   for (int i = 0; i < n_devices; ++i) {
-//     std::uintptr_t sendbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
-//     sendbuff = sendbuff + local_start_positions[i]*dtype_size;
-//     std::uintptr_t recvbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
-//     recvbuff = recvbuff + local_start_positions[i]*dtype_size;
-//     XLA_CUDA_RETURN_IF_ERROR(ncclBroadcast((void*)sendbuff, (void*)recvbuff, n_elements, dtype, root_rank, comms[i], streams[i]));
-//   }
-//   XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
-//   return Status::OK();
-// #else   // XLA_ENABLE_XCCL
-//   return Unimplemented("NCCL support is not available.");
-// #endif  // XLA_ENABLE_XCCL
-// }
+Status NcclSend(const collectiveStorage &storage,
+                PyBuffer::object buffer,
+                uint start,
+                uint n_elements,
+                int peer_p2p_rank) {
+#if XLA_ENABLE_XCCL
+  ncclDataType_t dtype = ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type());
+  int dtype_size = SizeOfType(dtype);
+  std::uintptr_t sendbuff = buffer.buf()->UnsafeBufferPointer().ValueOrDie();
+  sendbuff = sendbuff + start*dtype_size;
+  XLA_CUDA_RETURN_IF_ERROR(ncclSend((void*)sendbuff, n_elements, dtype, peer_p2p_rank, storage.comms[0], storage.streams[0]));
+  return Status::OK();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
 
-// Status NcclSend(std::vector<ncclComm_t> comms,
-//                 std::vector<cudaStream_t> streams,
-//                 PyBuffer::object buffer,
-//                 uint start,
-//                 uint n_elements,
-//                 int peer_p2p_rank) {
-// #if XLA_ENABLE_XCCL
-//   ncclDataType_t dtype = ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type());
-//   int dtype_size = SizeOfType(dtype);
-//   std::uintptr_t sendbuff = buffer.buf()->UnsafeBufferPointer().ValueOrDie();
-//   sendbuff = sendbuff + start*dtype_size;
-//   XLA_CUDA_RETURN_IF_ERROR(ncclSend((void*)sendbuff, n_elements, dtype, peer_p2p_rank, comms[0], streams[0]));
-//   return Status::OK();
-// #else   // XLA_ENABLE_XCCL
-//   return Unimplemented("NCCL support is not available.");
-// #endif  // XLA_ENABLE_XCCL
-// }
-
-// Status NcclRecv(std::vector<ncclComm_t> comms,
-//                 std::vector<cudaStream_t> streams,
-//                 PyBuffer::object buffer,
-//                 uint start,
-//                 uint n_elements,
-//                 int peer_p2p_rank) {
-// #if XLA_ENABLE_XCCL
-//   ncclDataType_t dtype = ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type());
-//   int dtype_size = SizeOfType(dtype);
-//   std::uintptr_t recvbuff = buffer.buf()->UnsafeBufferPointer().ValueOrDie();
-//   recvbuff = recvbuff + start*dtype_size;
-//   XLA_CUDA_RETURN_IF_ERROR(ncclRecv((void*)recvbuff, n_elements, dtype, peer_p2p_rank, comms[0], streams[0]));
-//   return Status::OK();
-// #else   // XLA_ENABLE_XCCL
-//   return Unimplemented("NCCL support is not available.");
-// #endif  // XLA_ENABLE_XCCL
-// }
+Status NcclRecv(const collectiveStorage &storage,
+                PyBuffer::object buffer,
+                uint start,
+                uint n_elements,
+                int peer_p2p_rank) {
+#if XLA_ENABLE_XCCL
+  ncclDataType_t dtype = ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type());
+  int dtype_size = SizeOfType(dtype);
+  std::uintptr_t recvbuff = buffer.buf()->UnsafeBufferPointer().ValueOrDie();
+  recvbuff = recvbuff + start*dtype_size;
+  XLA_CUDA_RETURN_IF_ERROR(ncclRecv((void*)recvbuff, n_elements, dtype, peer_p2p_rank, storage.comms[0], storage.streams[0]));
+  return Status::OK();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
 
 std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid) {
   std::vector<char> nccl_uid_vec(sizeof(nccl_uid.internal), 0);
@@ -307,36 +262,45 @@ StatusOr<int> NcclGetVersion() {
 #endif  // XLA_ENABLE_XCCL
 }
 
-// StatusOr< std::tuple<std::shared_ptr<std::vector<ncclComm_t>>, std::shared_ptr<std::vector<cudaStream_t>>>> NcclCreateCommunicators(int world_size, 
-//                                                                                                                                     std::vector<int> devices_global_rank, 
-//                                                                                                                                     std::vector<int> devices_ids, 
-//                                                                                                                                     std::vector<char> nccl_uid_vec) {
-// #if XLA_ENABLE_XCCL
-//   int n_devices = devices_global_rank.size();
-//   CHECK_EQ(n_devices, devices_ids.size());
+StatusOr< std::shared_ptr<collectiveStorage> > NcclCreateCommunicators(int world_size, 
+                                                                       std::vector<int> devices_global_rank, 
+                                                                       std::vector<int> devices_ids, 
+                                                                       std::vector<char> nccl_uid_vec) {
+#if XLA_ENABLE_XCCL
+  int n_devices = devices_global_rank.size();
+  CHECK_EQ(n_devices, devices_ids.size());
+  ncclUniqueId nccl_uid = NcclUidDeserialize(nccl_uid_vec);
 
-//   ncclUniqueId nccl_uid = NcclUidDeserialize(nccl_uid_vec);
-//   std::vector<ncclComm_t> comms;
-//   comms.resize(n_devices);
-//   std::vector<cudaStream_t> streams;
-//   streams.resize(n_devices);
-//   XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
-//   for (int i=0; i<n_devices; i++) {
-//     cudaSetDevice(devices_ids[i]);
-//     XLA_CUDA_RETURN_IF_ERROR(ncclCommInitRank(comms.data()+i, world_size, nccl_uid, devices_global_rank[i]));
-//     cudaStreamCreate(streams.data()+i);
-//   }
-//   XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
-//   return std::make_tuple(std::make_shared<std::vector<ncclComm_t>>(std::move(comms)), std::make_shared<std::vector<cudaStream_t>>(std::move(streams)));
-// #else   // XLA_ENABLE_XCCL
-//   return Unimplemented("NCCL support is not available.");
-// #endif  // XLA_ENABLE_XCCL
-// }
+  std::vector<ncclComm_t> comms;
+  comms.resize(n_devices);
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
+  for (int i=0; i<n_devices; i++) {
+    cudaSetDevice(devices_ids[i]);
+    XLA_CUDA_RETURN_IF_ERROR(ncclCommInitRank(comms.data()+i, world_size, nccl_uid, devices_global_rank[i]));
+  }
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
+
+  std::vector<cudaStream_t> streams;
+  streams.resize(n_devices);
+  for (int i=0; i<n_devices; i++) {
+    cudaSetDevice(devices_ids[i]);
+    // cudaStreamCreate(streams.data()+i);
+    cudaStreamCreateWithFlags(streams.data()+i, cudaStreamDefault);
+  }
+
+  collectiveStorage storage;
+  storage.comms = comms;
+  storage.streams = streams;
+  return std::make_shared<collectiveStorage>(std::move(storage));
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
 
 StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer) {
   return buffer.buf()->device()->local_hardware_id();
 }
 
-}  // namespace alpa_nccl
+}  // namespace gpu
 
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -69,35 +69,35 @@ ncclDataType_t ToNcclDataType(PrimitiveType element_type);
 
 int SizeOfType(ncclDataType_t element_type);
 
-class collectiveStorage {
+class NcclCommStorage {
   public:
     std::vector<ncclComm_t> comms;
     std::vector<cudaStream_t> streams;
 };
 
-StatusOr< std::shared_ptr<collectiveStorage> > NcclInitCommunicator(std::vector<int> devices_vec);
+StatusOr< std::shared_ptr<NcclCommStorage> > NcclInitCommunicator(std::vector<int> devices_vec);
 
-Status NcclLocalAllGather(const collectiveStorage &storage, 
+Status NcclLocalAllGather(const NcclCommStorage &storage, 
                           std::vector<PyBuffer::object> buffers, 
                           std::vector<uint> local_start_positions, 
                           uint global_start, 
                           uint n_elements);
 
-Status NcclDestroyComms(collectiveStorage &storage);
+Status NcclDestroyComms(NcclCommStorage &storage);
 
-Status NcclBroadcastPartialGPUs(const collectiveStorage &storage, 
+Status NcclBroadcastPartialGPUs(const NcclCommStorage &storage, 
                                 std::vector<PyBuffer::object> buffers, 
                                 std::vector<uint> local_start_positions, 
                                 uint n_elements, 
                                 int root_rank);
 
-Status NcclSend(const collectiveStorage &storage,
+Status NcclSend(const NcclCommStorage &storage,
                 PyBuffer::object buffer,
                 uint start,
                 uint n_elements, 
                 int peer_p2p_rank);
 
-Status NcclRecv(const collectiveStorage &storage,
+Status NcclRecv(const NcclCommStorage &storage,
                 PyBuffer::object buffer,
                 uint start,
                 uint n_elements,
@@ -111,10 +111,10 @@ StatusOr<std::vector<char> > NcclGetUniqueId();
 
 StatusOr<int> NcclGetVersion();
 
-StatusOr< std::shared_ptr<collectiveStorage> > NcclCreateCommunicators(int world_size,
-                                                                       std::vector<int> devices_global_rank,
-                                                                       std::vector<int> devices_ids,
-                                                                       std::vector<char> nccl_uid);
+StatusOr< std::shared_ptr<NcclCommStorage> > NcclCreateCommunicators(int world_size,
+                                                                     std::vector<int> devices_global_rank,
+                                                                     std::vector<int> devices_ids,
+                                                                     std::vector<char> nccl_uid);
 
 StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer);
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -65,9 +65,9 @@ Status ncclResultToStatus(ncclResult_t s, const char* file, int64_t line,
     }                                 \
   } while (0)
 
-// ncclDataType_t ToNcclDataType(PrimitiveType element_type);
+ncclDataType_t ToNcclDataType(PrimitiveType element_type);
 
-// int SizeOfType(ncclDataType_t element_type);
+int SizeOfType(ncclDataType_t element_type);
 
 class collectiveStorage {
   public:
@@ -75,64 +75,46 @@ class collectiveStorage {
     std::vector<cudaStream_t> streams;
 };
 
-// class collectiveStorage {
-//   public:
-//     ncclComm_t comm;
-//     cudaStream_t stream;
-
-//   collectiveStorage(ncclComm_t x, cudaStream_t y) {
-//     comm = x;
-//     stream = y;
-//   }
-// };
-
 StatusOr< std::shared_ptr<collectiveStorage> > NcclInitCommunicator(std::vector<int> devices_vec);
 
-// StatusOr< std::shared_ptr<std::vector<collectiveStorage> >> NcclInitCommunicator(std::vector<int> devices_vec);
-
-// StatusOr< std::tuple<std::shared_ptr<std::vector<ncclComm_t>>, std::shared_ptr<std::vector<cudaStream_t>>>> NcclInitCommunicator(std::vector<int> devices_vec);
-
-Status NcclLocalAllGather(collectiveStorage, 
+Status NcclLocalAllGather(const collectiveStorage &storage, 
                           std::vector<PyBuffer::object> buffers, 
                           std::vector<uint> local_start_positions, 
                           uint global_start, 
                           uint n_elements);
 
-// Status NcclDestroyComms(std::vector<ncclComm_t> comms);
+Status NcclDestroyComms(collectiveStorage &storage);
 
-// Status NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms, 
-//                                 std::vector<cudaStream_t> streams,
-//                                 std::vector<PyBuffer::object> buffers, 
-//                                 std::vector<uint> local_start_positions, 
-//                                 uint n_elements, 
-//                                 int root_rank);
+Status NcclBroadcastPartialGPUs(const collectiveStorage &storage, 
+                                std::vector<PyBuffer::object> buffers, 
+                                std::vector<uint> local_start_positions, 
+                                uint n_elements, 
+                                int root_rank);
 
-// Status NcclSend(std::vector<ncclComm_t> comms, 
-//                 std::vector<cudaStream_t> streams,
-//                 PyBuffer::object buffer, 
-//                 uint start, 
-//                 uint n_elements, 
-//                 int peer_p2p_rank);
+Status NcclSend(const collectiveStorage &storage,
+                PyBuffer::object buffer,
+                uint start,
+                uint n_elements, 
+                int peer_p2p_rank);
 
-// Status NcclRecv(std::vector<ncclComm_t> comms,
-//                 std::vector<cudaStream_t> streams,
-//                 PyBuffer::object buffer,
-//                 uint start,
-//                 uint n_elements,
-//                 int peer_p2p_rank);
+Status NcclRecv(const collectiveStorage &storage,
+                PyBuffer::object buffer,
+                uint start,
+                uint n_elements,
+                int peer_p2p_rank);
 
 std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid);
 
 ncclUniqueId NcclUidDeserialize(std::vector<char> nccl_uid_chars);
 
-StatusOr< std::vector<char> > NcclGetUniqueId();
+StatusOr<std::vector<char> > NcclGetUniqueId();
 
 StatusOr<int> NcclGetVersion();
 
-// StatusOr< std::tuple<std::shared_ptr<std::vector<ncclComm_t>>, std::shared_ptr<std::vector<cudaStream_t>>>> NcclCreateCommunicators(int world_size,
-//                                                                                                                                     std::vector<int> devices_global_rank,
-//                                                                                                                                     std::vector<int> devices_ids,
-//                                                                                                                                     std::vector<char> nccl_uid);
+StatusOr< std::shared_ptr<collectiveStorage> > NcclCreateCommunicators(int world_size,
+                                                                       std::vector<int> devices_global_rank,
+                                                                       std::vector<int> devices_ids,
+                                                                       std::vector<char> nccl_uid);
 
 StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer);
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -36,7 +36,6 @@ limitations under the License.
 #include "pybind11/cast.h"
 #include "pybind11/numpy.h"
 #include "pybind11/pytypes.h"
-#include "pybind11/stl_bind.h"
 
 #include "tensorflow/compiler/xla/python/py_buffer.h"
 #include "tensorflow/compiler/xla/python/py_client.h"
@@ -66,37 +65,61 @@ Status ncclResultToStatus(ncclResult_t s, const char* file, int64_t line,
     }                                 \
   } while (0)
 
-ncclDataType_t ToNcclDataType(PrimitiveType element_type);
+// ncclDataType_t ToNcclDataType(PrimitiveType element_type);
 
-int SizeOfType(ncclDataType_t element_type);
+// int SizeOfType(ncclDataType_t element_type);
 
-StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclInitCommunicator(std::vector<int> devices_vec);
+class collectiveStorage {
+  public:
+    std::vector<ncclComm_t> comms;
+    std::vector<cudaStream_t> streams;
+};
 
-Status NcclLocalAllGather(std::vector<ncclComm_t> comms, 
+// class collectiveStorage {
+//   public:
+//     ncclComm_t comm;
+//     cudaStream_t stream;
+
+//   collectiveStorage(ncclComm_t x, cudaStream_t y) {
+//     comm = x;
+//     stream = y;
+//   }
+// };
+
+StatusOr< std::shared_ptr<collectiveStorage> > NcclInitCommunicator(std::vector<int> devices_vec);
+
+// StatusOr< std::shared_ptr<std::vector<collectiveStorage> >> NcclInitCommunicator(std::vector<int> devices_vec);
+
+// StatusOr< std::tuple<std::shared_ptr<std::vector<ncclComm_t>>, std::shared_ptr<std::vector<cudaStream_t>>>> NcclInitCommunicator(std::vector<int> devices_vec);
+
+Status NcclLocalAllGather(collectiveStorage, 
                           std::vector<PyBuffer::object> buffers, 
                           std::vector<uint> local_start_positions, 
                           uint global_start, 
                           uint n_elements);
 
-Status NcclDestroyComms(std::vector<ncclComm_t> comms);
+// Status NcclDestroyComms(std::vector<ncclComm_t> comms);
 
-Status NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms, 
-                                std::vector<PyBuffer::object> buffers, 
-                                std::vector<uint> local_start_positions, 
-                                uint n_elements, 
-                                int root_rank);
+// Status NcclBroadcastPartialGPUs(std::vector<ncclComm_t> comms, 
+//                                 std::vector<cudaStream_t> streams,
+//                                 std::vector<PyBuffer::object> buffers, 
+//                                 std::vector<uint> local_start_positions, 
+//                                 uint n_elements, 
+//                                 int root_rank);
 
-Status NcclSend(std::vector<ncclComm_t> comms, 
-                PyBuffer::object buffer, 
-                uint start, 
-                uint n_elements, 
-                int peer_p2p_rank);
+// Status NcclSend(std::vector<ncclComm_t> comms, 
+//                 std::vector<cudaStream_t> streams,
+//                 PyBuffer::object buffer, 
+//                 uint start, 
+//                 uint n_elements, 
+//                 int peer_p2p_rank);
 
-Status NcclRecv(std::vector<ncclComm_t> comms,
-                PyBuffer::object buffer,
-                uint start,
-                uint n_elements,
-                int peer_p2p_rank);
+// Status NcclRecv(std::vector<ncclComm_t> comms,
+//                 std::vector<cudaStream_t> streams,
+//                 PyBuffer::object buffer,
+//                 uint start,
+//                 uint n_elements,
+//                 int peer_p2p_rank);
 
 std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid);
 
@@ -106,10 +129,10 @@ StatusOr< std::vector<char> > NcclGetUniqueId();
 
 StatusOr<int> NcclGetVersion();
 
-StatusOr< std::shared_ptr< std::vector<ncclComm_t> > > NcclCreateCommunicators(int world_size,
-                                                                               std::vector<int> devices_global_rank,
-                                                                               std::vector<int> devices_ids,
-                                                                               std::vector<char> nccl_uid);
+// StatusOr< std::tuple<std::shared_ptr<std::vector<ncclComm_t>>, std::shared_ptr<std::vector<cudaStream_t>>>> NcclCreateCommunicators(int world_size,
+//                                                                                                                                     std::vector<int> devices_global_rank,
+//                                                                                                                                     std::vector<int> devices_ids,
+//                                                                                                                                     std::vector<char> nccl_uid);
 
 StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer);
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -75,7 +75,7 @@ class NcclCommStorage {
     std::vector<cudaStream_t> streams;
 };
 
-StatusOr< std::shared_ptr<NcclCommStorage> > NcclInitCommunicator(std::vector<int> devices_vec);
+StatusOr< std::shared_ptr<NcclCommStorage> > NcclInitCommunicator(std::vector<int> devices_vec, bool nccl_use_multistream);
 
 Status NcclLocalAllGather(const NcclCommStorage &storage, 
                           std::vector<PyBuffer::object> buffers, 
@@ -114,7 +114,8 @@ StatusOr<int> NcclGetVersion();
 StatusOr< std::shared_ptr<NcclCommStorage> > NcclCreateCommunicators(int world_size,
                                                                      std::vector<int> devices_global_rank,
                                                                      std::vector<int> devices_ids,
-                                                                     std::vector<char> nccl_uid);
+                                                                     std::vector<char> nccl_uid,
+                                                                     bool nccl_use_multistream);
 
 StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer);
 


### PR DESCRIPTION
There is a bug related to cudaStreamLegacy (default stream) in early version of NCCL. This PR solves it. it uses cupy's solution that bypasses this bug with 0 pointer (in below picture). 

<img width="793" alt="image" src="https://user-images.githubusercontent.com/45677459/175406033-cae4700d-2d10-40cc-b1b0-a7890e7e0b34.png">
