### PR TITLE
Remove indivisble strategies

### DIFF
--- a/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
@@ -1396,6 +1396,8 @@ BuildStrategyAndCost(const HloInstructionSequence& sequence,
           strategies->childs.push_back(FollowInsStrategyVector(
               src_strategies, operand->shape(), instruction_id,
               /* have_memory_cost= */ false, leaf_strategies));
+          RemoveIndivisibleStrategies(strategies->childs.back(),
+                                      operand->shape());
         }
         break;
       }

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_strategy.h
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_strategy.h
@@ -1007,6 +1007,9 @@ std::unique_ptr<StrategyVector> CreateLeafStrategyVector(
 
 void RemoveDuplicatedStrategy(std::unique_ptr<StrategyVector>& strategies);
 
+void RemoveIndivisibleStrategies(std::unique_ptr<StrategyVector>& strategies,
+                                 const Shape& shape);
+
 Status FilterStrategy(const HloInstruction* ins,
                       std::unique_ptr<StrategyVector>& strategies,
                       const ClusterEnvironment& cluster_env,

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_util.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_util.cc
@@ -917,8 +917,8 @@ void RemoveDuplicatedStrategy(std::unique_ptr<StrategyVector>& strategies) {
   strategies->leaf_vector = std::move(new_vector);
 }
 
-// Remove strategies whose output tensor is not divisible by the tile factor
-// defined in the sharding spec.
+// Remove strategies whose output tensor's shape is not divisible by the tile
+// factors defined in the sharding spec.
 void RemoveIndivisibleStrategies(std::unique_ptr<StrategyVector>& strategies,
                                  const Shape& shape) {
   std::vector<ShardingStrategy> new_vector;


### PR DESCRIPTION
The output tensor of an HloModule will be sent to Jax, which requires divisible sharding spec.
This PR removes strategies whose output tensor's shape is not divisible by the tile factors defined in the sharding spec.
