### PR TITLE
Fix NCCL flaky correctness bug by synchronizing device

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -34,7 +34,6 @@ limitations under the License.
 #include "pybind11/pybind11.h"
 #include "pybind11/attr.h"
 #include "pybind11/cast.h"
-#include "pybind11/numpy.h"
 #include "pybind11/pytypes.h"
 
 #include "tensorflow/compiler/xla/python/py_buffer.h"
@@ -75,7 +74,7 @@ class NcclCommStorage {
     std::vector<cudaStream_t> streams;
 };
 
-StatusOr< std::shared_ptr<NcclCommStorage> > NcclInitCommunicator(std::vector<int> devices_vec, bool nccl_use_multistream);
+StatusOr<std::shared_ptr<NcclCommStorage>> NcclInitCommunicator(std::vector<int> devices_vec, bool nccl_use_multistream);
 
 Status NcclLocalAllGather(const NcclCommStorage &storage, 
                           std::vector<PyBuffer::object> buffers, 
@@ -107,15 +106,15 @@ std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid);
 
 ncclUniqueId NcclUidDeserialize(std::vector<char> nccl_uid_chars);
 
-StatusOr<std::vector<char> > NcclGetUniqueId();
+StatusOr<std::vector<char>> NcclGetUniqueId();
 
 StatusOr<int> NcclGetVersion();
 
-StatusOr< std::shared_ptr<NcclCommStorage> > NcclCreateCommunicators(int world_size,
-                                                                     std::vector<int> devices_global_rank,
-                                                                     std::vector<int> devices_ids,
-                                                                     std::vector<char> nccl_uid,
-                                                                     bool nccl_use_multistream);
+StatusOr<std::shared_ptr<NcclCommStorage>> NcclCreateCommunicators(int world_size,
+                                                                   std::vector<int> devices_global_rank,
+                                                                   std::vector<int> devices_ids,
+                                                                   std::vector<char> nccl_uid,
+                                                                   bool nccl_use_multistream);
 
 StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer);
 


### PR DESCRIPTION
(1) Fix flaky correctness bug by synchronizing device after each send/recv/broadcast/allgather operation. 
(2) requested changes from [#PR 121](https://github.com/alpa-projects/tensorflow-alpa/pull/121)

The following are three requested benchmark results, given I use `cudaDeviceSynchronize` here. 

<img width="894" alt="image" src="https://user-images.githubusercontent.com/45677459/177759980-64a56b79-eb62-4750-8361-2e7ce5a5c6cb.png">

<img width="886" alt="image" src="https://user-images.githubusercontent.com/45677459/177760018-64795232-23d5-4b48-898d-ee201f30121d.png">

<img width="893" alt="image" src="https://user-images.githubusercontent.com/45677459/177760101-586571f5-adf2-4b48-b54e-fc57df4302fe.png">
