### PR TITLE
Add event level synchronization and refactor nccl communicator api

### DIFF
--- a/tensorflow/compiler/xla/pjrt/local_device_state.cc
+++ b/tensorflow/compiler/xla/pjrt/local_device_state.cc
@@ -186,4 +186,12 @@ int LocalDeviceState::GetNewPrngSeed() {
   return x;
 }
 
+// Added by Alpa
+se::Stream* LocalDeviceState::GetLastDeviceToDeviceStream() {
+  absl::MutexLock lock(&mu_);
+  int i = next_device_to_device_stream_;
+  i = (i - 1) % device_to_device_streams_.size();
+  return device_to_device_streams_.at(i).get();
+}
+
 }  // namespace xla

--- a/tensorflow/compiler/xla/pjrt/local_device_state.h
+++ b/tensorflow/compiler/xla/pjrt/local_device_state.h
@@ -164,6 +164,9 @@ class LocalDeviceState {
 
   Status SynchronizeAllActivity();
 
+  // Added by Alpa
+  se::Stream* GetLastDeviceToDeviceStream();
+
  private:
   AllocationModel allocation_model_;
 

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -602,7 +602,6 @@ cc_library(
         "rng_thunk.h",
     ],
     deps = [
-        ":alpa_event_manager",
         ":backend_configs_cc",
         ":buffer_allocations",
         ":cusolver_context",
@@ -683,6 +682,8 @@ cc_library(
         "//tensorflow/tsl/platform:logging",
         "//tensorflow/tsl/platform:status",
         "//tensorflow/tsl/lib/gtl:map_util",
+        # Added by Alpa
+        ":alpa_event_manager",
     ] + if_gpu_is_configured([
         ":cholesky_thunk",
         ":precompiled_kernels",

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -579,6 +579,7 @@ cc_library(
         "sequential_thunk.cc",
         "while_thunk.cc",
         # Added by Alpa
+        "done_event_thunk.cc",
         "rng_thunk.cc",
     ],
     hdrs = [
@@ -597,9 +598,11 @@ cc_library(
         "sequential_thunk.h",
         "while_thunk.h",
         # Added by Alpa
+        "done_event_thunk.h",
         "rng_thunk.h",
     ],
     deps = [
+        ":alpa_event_manager",
         ":backend_configs_cc",
         ":buffer_allocations",
         ":cusolver_context",
@@ -1788,6 +1791,8 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Transforms",
+        # Added by Alpa
+        ":done_event_insertion",
     ],
 )
 
@@ -2986,32 +2991,33 @@ tf_cuda_library(
     ],
     compatible_with = [],
     defines = if_gpu_is_configured(["XLA_ENABLE_XCCL"]),
-    tags = ["manual"],  # Only builds with if_nccl().
-    deps = if_gpu_is_configured([
-        ":gpu_executable_run_options",
-        "@com_google_absl//absl/time",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/strings:str_format",
-        "@com_google_absl//absl/synchronization",
-        "//tensorflow/compiler/xla:debug_options_flags",
-        "//tensorflow/compiler/xla:status",
-        "//tensorflow/compiler/xla:status_macros",
-        "//tensorflow/compiler/xla:statusor",
-        "//tensorflow/compiler/xla:xla_data_proto_cc",
-        "//tensorflow/compiler/xla/service:collective_ops_utils",
-        "//tensorflow/compiler/xla/service:global_device_id",
-        "//tensorflow/compiler/xla/pjrt/distributed:client",
-        "//tensorflow/compiler/xla/pjrt:pjrt_client",
-        "//tensorflow/compiler/xla/pjrt:tfrt_cpu_pjrt_client",
+    deps = [
+        ":alpa_event_manager",
         "//tensorflow/compiler/xla/python:py_client",
-        "//tensorflow/compiler/xla/tools:driver",
-        "//tensorflow/core:lib",
-        "@pybind11",
+    ] + if_gpu_is_configured([
+        ":gpu_executable_run_options",
+        ":nccl_utils",
+        "//tensorflow/compiler/xla/stream_executor/gpu:gpu_stream",
     ]) + if_cuda_is_configured([
         "@local_config_nccl//:nccl",
     ]) + if_rocm_is_configured([
         "@local_config_rocm//rocm:rccl",
     ]),
+)
+
+cc_library(
+    name = "alpa_event_manager",
+    srcs = [
+        "alpa_events.cc",
+    ],
+    hdrs = [
+        "alpa_events.h",
+    ],
+    deps = [
+        "//tensorflow/compiler/xla:status_macros",
+        "//tensorflow/stream_executor:event",
+        "@com_google_absl//absl/container:flat_hash_map",
+    ],
 )
 
 cc_library(
@@ -3043,4 +3049,15 @@ cc_library(
         "//tensorflow/compiler/xla/service:pass_context",
         "//tensorflow/compiler/xla/service/spmd:auto_sharding",
     ],
+)
+
+cc_library(
+    name = "done_event_insertion", 
+    srcs = ["done_event_insertion.cc"], 
+    hdrs = ["done_event_insertion.h"], 
+    deps = [
+        "//tensorflow/compiler/xla:shape_util",
+        "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service:hlo_pass",
+    ]
 )

--- a/tensorflow/compiler/xla/service/gpu/alpa_events.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_events.cc
@@ -91,8 +91,6 @@ Status WaitEventOnStreams(int uuid,
   return OkStatus();
 }
 
-void ResetAlpaEvents() {
-  uuid_to_events = std::make_shared<UuidToEvent_t>();
-}
+void ResetAlpaEvents() { uuid_to_events = std::make_shared<UuidToEvent_t>(); }
 };  // namespace gpu
 };  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/alpa_events.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_events.cc
@@ -1,0 +1,105 @@
+#include <stack>
+
+#include "tensorflow/compiler/xla/service/gpu/alpa_events.h"
+
+// FIXME(yonghao): only record events used for cross-mesh resharding
+namespace xla {
+namespace gpu {
+absl::Mutex events_mu_;
+using UuidToEvent_t = absl::flat_hash_map<int, std::shared_ptr<DoneEventStats>>;
+std::shared_ptr<UuidToEvent_t> uuid_to_events =
+    std::make_shared<UuidToEvent_t>();
+std::vector<int> index_to_uuid;
+int num_devices = -1;
+
+void DoneEventStats::WaitForAllEventRecorded() {
+  absl::MutexLock lock(&stat_mutex);
+  auto all_event_recorded = [&]() { return record_counter == num_devices; };
+  stat_mutex.Await(absl::Condition(&all_event_recorded));
+}
+
+se::Event* DoneEventStats::RecordEvent(int device_ordinal,
+                                       se::StreamExecutor* executor) {
+  absl::MutexLock lock(&stat_mutex);
+  CHECK(record_counter < num_devices);
+  value_[device_ordinal] = std::make_unique<se::Event>(executor);
+  record_counter += 1;
+  return value_[device_ordinal].get();
+}
+
+Status DoneEventStats::WaitOnStreams(std::vector<se::Stream*>& streams) {
+  WaitForAllEventRecorded();
+  CHECK_EQ(streams.size(), num_devices);
+  for (int device_ordinal = 0; device_ordinal < num_devices; ++device_ordinal) {
+    streams[device_ordinal]->ThenWaitFor(value_[device_ordinal].get());
+  }
+  return OkStatus();
+}
+
+Status DoneEventStats::WaitOnStreams(
+    std::vector<std::unique_ptr<se::Stream>>& streams) {
+  WaitForAllEventRecorded();
+  CHECK_EQ(streams.size(), num_devices);
+  for (int device_ordinal = 0; device_ordinal < num_devices; ++device_ordinal) {
+    streams[device_ordinal]->ThenWaitFor(value_[device_ordinal].get());
+  }
+  return OkStatus();
+}
+
+void SetNumDeviceOnHost(int nd) { num_devices = nd; }
+
+Status XlaSetIdxToUuid(const std::vector<int>& mapping) {
+  index_to_uuid = mapping;
+  for (int uuid : mapping) {
+    ResetEvents(uuid);
+  }
+  return OkStatus();
+}
+
+Status ResetEvents(int uuid) {
+  absl::MutexLock lock(&events_mu_);
+  uuid_to_events->insert_or_assign(uuid, std::make_shared<DoneEventStats>());
+  return OkStatus();
+}
+
+se::Event* SetEvent(int uuid, int device_ordinal,
+                    se::StreamExecutor* executor) {
+  absl::MutexLock lock(&events_mu_);
+  return uuid_to_events->at(uuid)->RecordEvent(device_ordinal, executor);
+}
+
+std::shared_ptr<DoneEventStats> GetEventStats(int index) {
+  int uuid = index_to_uuid[index];
+  absl::MutexLock lock(&events_mu_);
+  return uuid_to_events->at(uuid);
+}
+
+Status WaitEventOnStreams(int uuid, std::vector<se::Stream*>& streams) {
+  absl::MutexLock lock(&events_mu_);
+  if (uuid_to_events->count(uuid)) {
+    TF_RETURN_IF_ERROR(uuid_to_events->at(uuid)->WaitOnStreams(streams));
+  }
+  return OkStatus();
+}
+
+Status WaitEventOnStreams(int uuid,
+                          std::vector<std::unique_ptr<se::Stream>>& streams) {
+  absl::MutexLock lock(&events_mu_);
+  if (uuid_to_events->count(uuid)) {
+    TF_RETURN_IF_ERROR(uuid_to_events->at(uuid)->WaitOnStreams(streams));
+  }
+  return OkStatus();
+}
+
+void ResetAlpaEvents() {
+  uuid_to_events = std::make_shared<UuidToEvent_t>();
+}
+
+void HoldAlpaEventsUntilStreamDone(se::Stream* stream) {
+  std::shared_ptr<UuidToEvent_t> events_ref = uuid_to_events;
+  stream->ThenDoHostCallback([events_ref] () {
+    // Hold events until done
+  });
+}
+};  // namespace gpu
+};  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/alpa_events.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_events.cc
@@ -94,12 +94,5 @@ Status WaitEventOnStreams(int uuid,
 void ResetAlpaEvents() {
   uuid_to_events = std::make_shared<UuidToEvent_t>();
 }
-
-void HoldAlpaEventsUntilStreamDone(se::Stream* stream) {
-  std::shared_ptr<UuidToEvent_t> events_ref = uuid_to_events;
-  stream->ThenDoHostCallback([events_ref] () {
-    // Hold events until done
-  });
-}
 };  // namespace gpu
 };  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/alpa_events.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_events.h
@@ -1,0 +1,61 @@
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_ALPA_EVENTS_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_ALPA_EVENTS_H_
+
+#include "absl/container/flat_hash_map.h"
+#include "tensorflow/compiler/xla/status_macros.h"
+#include "tensorflow/stream_executor/stream.h"
+// This file provides APIs to sync Alpa's multi-stream behavior with
+// XLA's own streams
+namespace xla {
+namespace gpu {
+namespace se = ::stream_executor;
+
+class DoneEventStats {
+
+ public:
+  void WaitForAllEventRecorded();
+  se::Event* RecordEvent(int device_ordinal,
+                         se::StreamExecutor* executor);
+  Status WaitOnStreams(std::vector<se::Stream*>& streams);
+  Status WaitOnStreams(std::vector<std::unique_ptr<se::Stream>>& streams);
+
+  bool empty() const { return value_.empty(); }
+
+ private:
+  absl::Mutex stat_mutex;
+  int64_t record_counter ABSL_GUARDED_BY(stat_mutex) = 0;
+  absl::flat_hash_map<int, std::unique_ptr<se::Event>> value_;
+};
+
+// Init function
+void SetNumDeviceOnHost(int nd);
+
+// Set idx to uuid for computations to record events
+Status XlaSetIdxToUuid(const std::vector<int>& mapping);
+
+// Reset event ids
+Status ResetEvents(int uuid);
+
+// Set events for communications to record events
+se::Event* SetEvent(int uuid, int device_ordinal, se::StreamExecutor* executor);
+
+// Get event stats for computation to record it
+std::shared_ptr<DoneEventStats> GetEventStats(int index);
+
+// Sync events
+Status WaitEventOnStreams(int uuid, std::vector<se::Stream*>& streams);
+
+Status WaitEventOnStreams(int uuid,
+                          std::vector<std::unique_ptr<se::Stream>>& streams);
+
+// Manage event stacks
+// In case we only use events in cross-mesh communication and all of them are
+// inside a PipeShardExecutable, we can reset it at the beginning of a
+// PipeShardExecutable.
+void ResetAlpaEvents();
+
+// release events after all computation finishes by a callback.
+void HoldAlpaEventsUntilStreamDone(se::Stream* stream);
+};      // namespace gpu
+};      // namespace xla
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_ALPA_EVENTS_H_

--- a/tensorflow/compiler/xla/service/gpu/alpa_events.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_events.h
@@ -53,9 +53,6 @@ Status WaitEventOnStreams(int uuid,
 // inside a PipeShardExecutable, we can reset it at the beginning of a
 // PipeShardExecutable.
 void ResetAlpaEvents();
-
-// release events after all computation finishes by a callback.
-void HoldAlpaEventsUntilStreamDone(se::Stream* stream);
 };      // namespace gpu
 };      // namespace xla
 #endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_ALPA_EVENTS_H_

--- a/tensorflow/compiler/xla/service/gpu/alpa_events.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_events.h
@@ -11,11 +11,9 @@ namespace gpu {
 namespace se = ::stream_executor;
 
 class DoneEventStats {
-
  public:
   void WaitForAllEventRecorded();
-  se::Event* RecordEvent(int device_ordinal,
-                         se::StreamExecutor* executor);
+  se::Event* RecordEvent(int device_ordinal, se::StreamExecutor* executor);
   Status WaitOnStreams(std::vector<se::Stream*>& streams);
   Status WaitOnStreams(std::vector<std::unique_ptr<se::Stream>>& streams);
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -360,9 +360,6 @@ Status ComputationWaitEvents(const AlpaUuids &uuids,
 
 // Event context management
 void ResetEventContext(std::shared_ptr<PyClient> client) {
-  // PjRtStreamExecutorClient *pjrt_client =
-  //     tensorflow::down_cast<PjRtStreamExecutorClient *>(client->pjrt_client());
-  // HoldAlpaEventsUntilStreamDone(pjrt_client->device_state(0).compute_stream());
   ResetAlpaEvents();
 }
 // Other functions

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -367,24 +367,24 @@ Status ComputationWaitEvents(const AlpaUuids &uuids,
 // Event context management
 void ResetEventContext(std::shared_ptr<PyClient> client) { ResetAlpaEvents(); }
 // Other functions
-std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid) {
-  std::vector<char> nccl_uid_vec(sizeof(nccl_uid.internal), 0);
+AlpaNcclUid NcclUidSerialize(ncclUniqueId nccl_uid) {
+  AlpaNcclUid nccl_uid_vec(sizeof(nccl_uid.internal), 0);
   memcpy(nccl_uid_vec.data(), &nccl_uid.internal, sizeof(nccl_uid.internal));
   return nccl_uid_vec;
 }
 
-ncclUniqueId NcclUidDeserialize(std::vector<char> nccl_uid_vec) {
+ncclUniqueId NcclUidDeserialize(const AlpaNcclUid& nccl_uid_vec) {
   ncclUniqueId nccl_uid;
   CHECK_EQ(sizeof(nccl_uid.internal), nccl_uid_vec.size());
   memcpy(&nccl_uid.internal, nccl_uid_vec.data(), sizeof(nccl_uid.internal));
   return nccl_uid;
 }
 
-StatusOr<std::vector<char>> NcclGetUniqueId() {
+StatusOr<AlpaNcclUid> NcclGetUniqueId() {
 #if XLA_ENABLE_XCCL
   ncclUniqueId id;
   XLA_CUDA_RETURN_IF_ERROR(ncclGetUniqueId(&id));
-  std::vector<char> nccl_uid_vec = NcclUidSerialize(id);
+  AlpaNcclUid nccl_uid_vec = NcclUidSerialize(id);
   return nccl_uid_vec;
 #else   // XLA_ENABLE_XCCL
   return Unimplemented("NCCL support is not available.");

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -13,37 +13,36 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// This file implements nccl apis for alpa to use. 
-#ifdef XLA_ENABLE_XCCL
+// This file implements nccl apis for alpa to use.
 #include "tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h"
 
-#include <memory>
-#include <utility>
-#include <stdexcept>
+#include "tensorflow/compiler/xla/python/py_executable.h"
 
-#include "absl/strings/str_format.h"
-#include "tensorflow/compiler/xla/debug_options_flags.h"
-#include "tensorflow/compiler/xla/service/global_device_id.h"
-#include "tensorflow/compiler/xla/status_macros.h"
-#include "tensorflow/compiler/xla/statusor.h"
-
+# ifdef XLA_ENABLE_XCCL
+#include "tensorflow/compiler/xla/service/gpu/alpa_events.h"
+#include "tensorflow/compiler/xla/stream_executor/gpu/gpu_stream.h"
 #include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime.h"
+# endif
+
+namespace stream_executor {};
+namespace se = ::stream_executor;
 
 namespace xla {
 namespace gpu {
 
-Status ncclResultToStatus(ncclResult_t s, const char* file, int64_t line,
-                          const char* expr) {
-  if (s == ncclSuccess) {
-    return Status::OK();
-  }
-  return tensorflow::errors::Internal(
-      absl::StrFormat("%s:%d: NCCL operation %s failed: %s", file, line, expr,
-                      ncclGetErrorString(s)));
+namespace alpa {
+namespace {
+void AddCallBackReleasingBuffer(se::Stream* stream, PyBuffer::object &buf_obj) {
+  // Holding the shared ptr of the buffer because we use it in an unsafe way.
+  // This prevents XLA from freeing the buffer.
+  std::shared_ptr<PjRtBuffer> pjrt_ref = buf_obj.buf()->shared_ptr_buffer();
+  // TODO(yonghao): shall we add a usage hold for the buffer here?
+  // Follows the HostCallback in cuda_gpu_executor.cc
+  stream->ThenDoHostCallback([pjrt_ref]() {});
 }
 
-ncclDataType_t ToNcclDataType(PrimitiveType element_type) {
+StatusOr<ncclDataType_t> ToNcclDataType(PrimitiveType element_type) {
+  // FIXME(yonghao): throw an error for other cases
   switch (element_type) {
     case S8:
       return ncclInt8;
@@ -66,6 +65,8 @@ ncclDataType_t ToNcclDataType(PrimitiveType element_type) {
     case F64:
     case C128:
       return ncclFloat64;
+    default:
+      return Unimplemented("Nccl does not support the type.");
   }
 }
 
@@ -94,146 +95,277 @@ int SizeOfType(ncclDataType_t element_type) {
   }
 }
 
-StatusOr<std::shared_ptr<NcclCommStorage>> NcclInitCommunicator(std::vector<int> devices_vec, bool nccl_use_multistream) {
-#if XLA_ENABLE_XCCL
-    int n_devices = devices_vec.size();
-    std::vector<ncclComm_t> comms;
-    comms.resize(n_devices);
-    XLA_CUDA_RETURN_IF_ERROR(ncclCommInitAll(comms.data(), n_devices, devices_vec.data()));
+CUstream GetCudaStream(se::Stream *stream) {
+  return reinterpret_cast<CUstream>(se::gpu::AsGpuStreamValue(stream));
+}
 
-    std::vector<cudaStream_t> streams;
-    streams.resize(n_devices);
-    for (int i = 0; i < n_devices; ++i) {
-      cudaSetDevice(devices_vec[i]);
-      if (nccl_use_multistream) {
-        cudaStreamCreate(streams.data()+i);
-      } else {
-        streams[i] = (std::uintptr_t)0;
-        //TODO(hexu): move to cudaStreamLegacy(0x01), it wasn't possible because of a bug in older version nccl(<=2.8.4).
-      }
+se::Stream *GetXlaStream(PjRtStreamExecutorClient *client, bool is_compute,
+                         int device_id) {
+  return is_compute ? client->device_state(device_id).compute_stream()
+                    : client->device_state(0).GetLastDeviceToDeviceStream();
+}
+// key: (GroupId, global_rank)
+ThreadSafeMap<std::pair<AlpaNcclUid, int>, NcclComm> comm_map;
+// key: local_id
+CUstream default_stream = NULL;
+};  // namespace
+
+CommGroup::CommGroup(std::shared_ptr<PyClient> backend) {
+  if (backend != nullptr) {
+    client = tensorflow::down_cast<PjRtStreamExecutorClient *>(
+        backend->pjrt_client());
+    for (int device_id = 0; device_id < client->device_count(); ++device_id) {
+      auto executor = client->device_state(device_id).executor();
+      auto i_stream = std::make_unique<se::Stream>(executor);
+      auto o_stream = std::make_unique<se::Stream>(executor);
+      i_stream->Init();
+      o_stream->Init();
+      recv_streams.emplace_back(std::move(i_stream));
+      send_streams.emplace_back(std::move(o_stream));
+      executors.push_back(executor);
     }
-    NcclCommStorage storage;
-    storage.comms = comms;
-    storage.streams = streams;
-    return std::make_shared<NcclCommStorage>(std::move(storage));
+  }
+}
+
+// Communicator related functions:
+Status CommGroup::NcclCreateCommunicators(
+    int world_size, const std::vector<int> &device_global_ranks,
+    const std::vector<int> &device_ids, const AlpaNcclUid &nccl_uid_vec) {
+#if XLA_ENABLE_XCCL
+  int n_devices = device_global_ranks.size();
+  CHECK_EQ(n_devices, device_ids.size());
+  ncclUniqueId nccl_uid = NcclUidDeserialize(nccl_uid_vec);
+  // Create Communicators
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
+  for (int i = 0; i < n_devices; i++) {
+    cudaSetDevice(device_ids[i]);
+    int rank = device_global_ranks[i];
+    auto comm_key = std::make_pair(nccl_uid_vec, device_ids[i]);
+    NcclComm::Lock comm = comm_map[comm_key].Acquire();
+    XLA_CUDA_RETURN_IF_ERROR(
+        ncclCommInitRank(comm.get(), world_size, nccl_uid, rank));
+  }
+  local_ids[nccl_uid_vec] = device_ids;
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
+  return OkStatus();
 #else   // XLA_ENABLE_XCCL
   return Unimplemented("NCCL support is not available.");
 #endif  // XLA_ENABLE_XCCL
 }
 
-Status NcclLocalAllGather(const NcclCommStorage &storage,
-                          std::vector<PyBuffer::object> buffers,
-                          std::vector<uint> local_start_positions, // TODO(hexu): is the range of uint too small?
-                          uint global_start, 
-                          uint n_elements) {
+Status CommGroup::NcclDestroyComms(const AlpaNcclUid &nccl_uid_vec) {
 #if XLA_ENABLE_XCCL
-  int n_devices = storage.comms.size();
+  for (int device_id : local_ids[nccl_uid_vec]) {
+    auto key = std::make_pair(nccl_uid_vec, device_id);
+    XLA_CUDA_RETURN_IF_ERROR(ncclCommDestroy(*comm_map[key].Acquire()));
+  }
+  return OkStatus();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
+
+// Communication operation related functions:
+// FIXME: local allgather is deprecated
+Status CommGroup::NcclLocalAllGather(const AlpaNcclUid &key,
+                                     std::vector<PyBuffer::object> buffers,
+                                     std::vector<uint> local_start_positions,
+                                     uint global_start, uint n_elements,
+                                     bool use_default_stream) {
+#if XLA_ENABLE_XCCL
+  const auto &device_ids = local_ids[key];
+  int n_devices = device_ids.size();
   CHECK_EQ(n_devices, buffers.size());
   CHECK_EQ(n_devices, local_start_positions.size());
-  CHECK_EQ(n_devices, storage.streams.size());
 
-  ncclDataType_t dtype = ToNcclDataType(buffers[0].buf()->buffer()->on_device_shape().element_type());
+  TF_ASSIGN_OR_RETURN(ncclDataType_t dtype, ToNcclDataType(
+      buffers[0].buf()->buffer()->on_device_shape().element_type()));
   int dtype_size = SizeOfType(dtype);
   XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
   for (int i = 0; i < n_devices; ++i) {
-    std::uintptr_t sendbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
-    sendbuff = sendbuff + local_start_positions[i]*dtype_size;
-    std::uintptr_t recvbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
-    recvbuff = recvbuff + global_start*dtype_size;
-    XLA_CUDA_RETURN_IF_ERROR(ncclAllGather((void*)sendbuff, (void*)recvbuff, n_elements, dtype, storage.comms[i], storage.streams[i]));
+    // FIXME(yonghao): use assign or return
+    TF_ASSIGN_OR_RETURN(std::uintptr_t sendbuff,
+                        buffers[i].buf()->UnsafeBufferPointer());
+    sendbuff = sendbuff + local_start_positions[i] * dtype_size;
+    TF_ASSIGN_OR_RETURN(std::uintptr_t recvbuff,
+                        buffers[i].buf()->UnsafeBufferPointer());
+    recvbuff = recvbuff + global_start * dtype_size;
+    auto comm = *comm_map[std::make_pair(key, device_ids[i])].Acquire();
+    auto stream = (use_default_stream ? default_stream
+                                      : GetCudaStream(recv_streams[i].get()));
+    XLA_CUDA_RETURN_IF_ERROR(ncclAllGather((void *)sendbuff, (void *)recvbuff,
+                                           n_elements, dtype, comm, stream));
   }
   XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
-  for (int i = 0; i < n_devices; ++i) {  //TODO(hexu): will deprecate when overlapping is done.
-    cudaSetDevice(GetBufferDeviceId(buffers[i]).ValueOrDie());
-    cudaDeviceSynchronize();
-  }
-
-  return Status::OK();
+  return OkStatus();
 #else   // XLA_ENABLE_XCCL
   return Unimplemented("NCCL support is not available.");
 #endif  // XLA_ENABLE_XCCL
 }
 
-Status NcclDestroyComms(NcclCommStorage &storage) {
+Status CommGroup::NcclBroadcastPartialGPUs(
+    const AlpaNcclUid &key, std::vector<PyBuffer::object> buffers,
+    std::vector<uint> local_start_positions, uint n_elements, int root_rank,
+    bool use_recv_stream, bool use_default_stream) {
 #if XLA_ENABLE_XCCL
-  for (auto comm : storage.comms) 
-    XLA_CUDA_RETURN_IF_ERROR(ncclCommDestroy(comm));
-  return Status::OK();
-#else   // XLA_ENABLE_XCCL
-  return Unimplemented("NCCL support is not available.");
-#endif  // XLA_ENABLE_XCCL
-}
-
-Status NcclBroadcastPartialGPUs(const NcclCommStorage &storage,
-                                std::vector<PyBuffer::object> buffers,
-                                std::vector<uint> local_start_positions,
-                                uint n_elements,
-                                int root_rank) {
-#if XLA_ENABLE_XCCL
-  int n_devices = storage.comms.size();
+  const auto &device_ids = local_ids[key];
+  int n_devices = device_ids.size();
   CHECK_EQ(n_devices, buffers.size());
   CHECK_EQ(n_devices, local_start_positions.size());
-  CHECK_EQ(n_devices, storage.streams.size());
 
-  ncclDataType_t dtype = ToNcclDataType(buffers[0].buf()->buffer()->on_device_shape().element_type());
+  TF_ASSIGN_OR_RETURN(ncclDataType_t dtype, ToNcclDataType(
+      buffers[0].buf()->buffer()->on_device_shape().element_type()));
   int dtype_size = SizeOfType(dtype);
+
   XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
   for (int i = 0; i < n_devices; ++i) {
-    std::uintptr_t sendbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
-    sendbuff = sendbuff + local_start_positions[i]*dtype_size;
-    std::uintptr_t recvbuff = buffers[i].buf()->UnsafeBufferPointer().ValueOrDie();
-    recvbuff = recvbuff + local_start_positions[i]*dtype_size;
-    XLA_CUDA_RETURN_IF_ERROR(ncclBroadcast((void*)sendbuff, (void*)recvbuff, n_elements, dtype, root_rank, storage.comms[i], storage.streams[i]));
+    int device_id = device_ids[i];
+    TF_ASSIGN_OR_RETURN(std::uintptr_t sendbuff,
+                        buffers[i].buf()->UnsafeBufferPointer());
+    sendbuff = sendbuff + local_start_positions[i] * dtype_size;
+    TF_ASSIGN_OR_RETURN(std::uintptr_t recvbuff,
+                        buffers[i].buf()->UnsafeBufferPointer());
+    recvbuff = recvbuff + local_start_positions[i] * dtype_size;
+
+    auto comm = *comm_map[std::make_pair(key, device_id)].Acquire();
+    auto se_stream = use_default_stream
+                         ? nullptr
+                         : use_recv_stream ? recv_streams[device_id].get()
+                                           : send_streams[device_id].get();
+    auto stream =
+        use_default_stream ? default_stream : GetCudaStream(se_stream);
+    XLA_CUDA_RETURN_IF_ERROR(ncclBroadcast((void *)sendbuff, (void *)recvbuff,
+                                           n_elements, dtype, root_rank, comm,
+                                           stream));
+    if (!use_recv_stream && !use_default_stream) {
+      AddCallBackReleasingBuffer(se_stream, buffers[i]);
+    }
   }
   XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
-  for (int i = 0; i < n_devices; ++i) {
-    cudaSetDevice(GetBufferDeviceId(buffers[i]).ValueOrDie());
-    cudaDeviceSynchronize();
+  return OkStatus();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
+
+Status CommGroup::NcclSend(const AlpaNcclUid &key, PyBuffer::object buffer,
+                           uint start, uint n_elements, int peer_p2p_rank,
+                           bool use_default_stream) {
+#if XLA_ENABLE_XCCL
+  const int device_id = local_ids[key][0];
+  TF_ASSIGN_OR_RETURN(ncclDataType_t dtype, ToNcclDataType(
+      buffer.buf()->buffer()->on_device_shape().element_type()));
+  int dtype_size = SizeOfType(dtype);
+  TF_ASSIGN_OR_RETURN(std::uintptr_t sendbuff,
+                      buffer.buf()->UnsafeBufferPointer());
+  sendbuff = sendbuff + start * dtype_size;
+  auto comm = *comm_map[std::make_pair(key, device_id)].Acquire();
+  auto stream = use_default_stream
+                    ? default_stream
+                    : GetCudaStream(send_streams[device_id].get());
+  XLA_CUDA_RETURN_IF_ERROR(ncclSend((void *)sendbuff, n_elements, dtype,
+                                    peer_p2p_rank, comm, stream));
+  if (!use_default_stream) {
+    AddCallBackReleasingBuffer(send_streams[device_id].get(), buffer);
   }
-  return Status::OK();
+  // cudaDeviceSynchronize();
+  return OkStatus();
 #else   // XLA_ENABLE_XCCL
   return Unimplemented("NCCL support is not available.");
 #endif  // XLA_ENABLE_XCCL
 }
 
-Status NcclSend(const NcclCommStorage &storage,
-                PyBuffer::object buffer,
-                uint start,
-                uint n_elements,
-                int peer_p2p_rank) {
+Status CommGroup::NcclRecv(const AlpaNcclUid &key, PyBuffer::object buffer,
+                           uint start, uint n_elements, int peer_p2p_rank,
+                           bool use_default_stream) {
 #if XLA_ENABLE_XCCL
-  ncclDataType_t dtype = ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type());
+  const int device_id = local_ids[key][0];
+  TF_ASSIGN_OR_RETURN(ncclDataType_t dtype, ToNcclDataType(
+      buffer.buf()->buffer()->on_device_shape().element_type()));
   int dtype_size = SizeOfType(dtype);
-  std::uintptr_t sendbuff = buffer.buf()->UnsafeBufferPointer().ValueOrDie();
-  sendbuff = sendbuff + start*dtype_size;
-  XLA_CUDA_RETURN_IF_ERROR(ncclSend((void*)sendbuff, n_elements, dtype, peer_p2p_rank, storage.comms[0], storage.streams[0]));
-  cudaSetDevice(GetBufferDeviceId(buffer).ValueOrDie());
-  cudaDeviceSynchronize();
-  return Status::OK();
+  TF_ASSIGN_OR_RETURN(std::uintptr_t recvbuff,
+                      buffer.buf()->UnsafeBufferPointer());
+  recvbuff = recvbuff + start * dtype_size;
+  auto comm = *comm_map[std::make_pair(key, device_id)].Acquire();
+  auto stream = use_default_stream
+                    ? default_stream
+                    : GetCudaStream(recv_streams[device_id].get());
+  XLA_CUDA_RETURN_IF_ERROR(ncclRecv((void *)recvbuff, n_elements, dtype,
+                                    peer_p2p_rank, comm, stream));
+  // TF_RETURN_IF_ERROR(AddCallBackReleasingBuffer(stream, buffer));
+  // cudaDeviceSynchronize();
+  return OkStatus();
 #else   // XLA_ENABLE_XCCL
   return Unimplemented("NCCL support is not available.");
 #endif  // XLA_ENABLE_XCCL
 }
 
-Status NcclRecv(const NcclCommStorage &storage,
-                PyBuffer::object buffer,
-                uint start,
-                uint n_elements,
-                int peer_p2p_rank) {
-#if XLA_ENABLE_XCCL
-  ncclDataType_t dtype = ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type());
-  int dtype_size = SizeOfType(dtype);
-  std::uintptr_t recvbuff = buffer.buf()->UnsafeBufferPointer().ValueOrDie();
-  recvbuff = recvbuff + start*dtype_size;
-  XLA_CUDA_RETURN_IF_ERROR(ncclRecv((void*)recvbuff, n_elements, dtype, peer_p2p_rank, storage.comms[0], storage.streams[0]));
-  cudaSetDevice(GetBufferDeviceId(buffer).ValueOrDie());
-  cudaDeviceSynchronize();
-  return Status::OK();
-#else   // XLA_ENABLE_XCCL
-  return Unimplemented("NCCL support is not available.");
-#endif  // XLA_ENABLE_XCCL
+// Sync functions:
+Status CommGroup::CommunicatorRecordEvents(const AlpaUuids &uuids,
+                                           int num_devices, bool is_send) {
+  for (int uuid : uuids) {
+    TF_RETURN_IF_ERROR(ResetEvents(uuid));
+  }
+  for (int device_id = 0; device_id < num_devices; ++device_id) {
+    se::Stream *stream =
+        is_send ? send_streams[device_id].get() : recv_streams[device_id].get();
+    for (int uuid : uuids) {
+      se::Event *event = SetEvent(uuid, device_id, executors[device_id]);
+      TF_RET_CHECK(event->Init());
+      stream->ThenRecordEvent(event);
+    }
+  }
+  return OkStatus();
 }
 
+Status CommGroup::CommunicatorWaitEvents(const AlpaUuids &uuids,
+                                         int num_devices, bool is_send) {
+  auto &streams = is_send ? send_streams : recv_streams;
+  for (int uuid : uuids) {
+    TF_RETURN_IF_ERROR(WaitEventOnStreams(uuid, streams));
+  }
+  return OkStatus();
+}
+
+void CommGroup::CommWaitCompute(bool is_send, bool is_compute, int device_id) {
+  se::Stream *waited = GetXlaStream(client, is_compute, device_id);
+  se::Stream *waiting =
+      is_send ? send_streams[device_id].get() : recv_streams[device_id].get();
+  waiting->ThenWaitFor(waited);
+}
+
+void CommGroup::ComputeWaitComm(bool is_send, bool is_compute, int device_id) {
+  se::Stream *waiting = GetXlaStream(client, is_compute, device_id);
+  se::Stream *waited =
+      is_send ? send_streams[device_id].get() : recv_streams[device_id].get();
+  waiting->ThenWaitFor(waited);
+}
+
+// Sync function
+Status ComputationWaitEvents(const AlpaUuids &uuids,
+                             std::shared_ptr<PyClient> client) {
+  std::vector<se::Stream *> streams;
+  PjRtStreamExecutorClient *pjrt_client =
+      tensorflow::down_cast<PjRtStreamExecutorClient *>(client->pjrt_client());
+  int num_devices = pjrt_client->device_count();
+  for (int device_ordinal = 0; device_ordinal < num_devices; ++device_ordinal) {
+    streams.push_back(
+        pjrt_client->device_state(device_ordinal).compute_stream());
+  }
+  for (int uuid : uuids) {
+    TF_RETURN_IF_ERROR(WaitEventOnStreams(uuid, streams));
+  }
+  return OkStatus();
+}
+
+// Event context management
+void ResetEventContext(std::shared_ptr<PyClient> client) {
+  // PjRtStreamExecutorClient *pjrt_client =
+  //     tensorflow::down_cast<PjRtStreamExecutorClient *>(client->pjrt_client());
+  // HoldAlpaEventsUntilStreamDone(pjrt_client->device_state(0).compute_stream());
+  ResetAlpaEvents();
+}
+// Other functions
 std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid) {
   std::vector<char> nccl_uid_vec(sizeof(nccl_uid.internal), 0);
   memcpy(nccl_uid_vec.data(), &nccl_uid.internal, sizeof(nccl_uid.internal));
@@ -268,75 +400,9 @@ StatusOr<int> NcclGetVersion() {
 #endif  // XLA_ENABLE_XCCL
 }
 
-StatusOr<std::shared_ptr<NcclCommStorage>> NcclCreateCommunicators(int world_size, 
-                                                                   std::vector<int> devices_global_rank, 
-                                                                   std::vector<int> devices_ids, 
-                                                                   std::vector<char> nccl_uid_vec, 
-                                                                   bool nccl_use_multistream) {
-#if XLA_ENABLE_XCCL
-  int n_devices = devices_global_rank.size();
-  CHECK_EQ(n_devices, devices_ids.size());
-  ncclUniqueId nccl_uid = NcclUidDeserialize(nccl_uid_vec);
-
-  std::vector<ncclComm_t> comms;
-  comms.resize(n_devices);
-  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
-  for (int i=0; i<n_devices; i++) {
-    cudaSetDevice(devices_ids[i]);
-    XLA_CUDA_RETURN_IF_ERROR(ncclCommInitRank(comms.data()+i, world_size, nccl_uid, devices_global_rank[i]));
-  }
-  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
-
-  std::vector<cudaStream_t> streams;
-  streams.resize(n_devices);
-  for (int i=0; i<n_devices; i++) {
-    cudaSetDevice(devices_ids[i]);
-    if (nccl_use_multistream) {
-      cudaStreamCreate(streams.data()+i);
-    } else {
-      streams[i] = (std::uintptr_t)0;
-    }
-  }
-
-  NcclCommStorage storage;
-  storage.comms = comms;
-  storage.streams = streams;
-  return std::make_shared<NcclCommStorage>(std::move(storage));
-#else   // XLA_ENABLE_XCCL
-  return Unimplemented("NCCL support is not available.");
-#endif  // XLA_ENABLE_XCCL
-}
-
 StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer) {
   return buffer.buf()->device()->local_hardware_id();
 }
-
-StatusOr<std::vector<std::uintptr_t>> NcclCreateCommunicatorsNoStream(
-    int world_size, std::vector<int> devices_global_rank,
-    std::vector<int> devices_ids, std::vector<int8_t> nccl_uid_vec) {
-#if XLA_ENABLE_XCCL
-  int n_devices = devices_global_rank.size();
-  CHECK_EQ(n_devices, devices_ids.size());
-  ncclUniqueId nccl_uid;
-  CHECK_EQ(sizeof(nccl_uid.internal), nccl_uid_vec.size());
-  memcpy(&nccl_uid.internal, nccl_uid_vec.data(), sizeof(nccl_uid.internal));
-
-  std::vector<std::uintptr_t> comms;
-  comms.resize(n_devices);
-  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
-  for (int i = 0; i < n_devices; i++) {
-    cudaSetDevice(devices_ids[i]);
-    ncclComm_t* comm_ref = reinterpret_cast<ncclComm_t*>(comms.data() + i);
-    XLA_CUDA_RETURN_IF_ERROR(ncclCommInitRank(
-        comm_ref, world_size, nccl_uid, devices_global_rank[i]));
-  }
-  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
-  return comms;
-#else   // XLA_ENABLE_XCCL
-  return Unimplemented("NCCL support is not available.");
-#endif  // XLA_ENABLE_XCCL
-}
+}  // namespace alpa
 }  // namespace gpu
-
 }  // namespace xla
-#endif // XLA_ENABLE_XCCL

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -18,11 +18,11 @@ limitations under the License.
 
 #include "tensorflow/compiler/xla/python/py_executable.h"
 
-# ifdef XLA_ENABLE_XCCL
+#ifdef XLA_ENABLE_XCCL
 #include "tensorflow/compiler/xla/service/gpu/alpa_events.h"
 #include "tensorflow/compiler/xla/stream_executor/gpu/gpu_stream.h"
 #include "third_party/gpus/cuda/include/cuda.h"
-# endif
+#endif
 
 namespace stream_executor {};
 namespace se = ::stream_executor;
@@ -32,7 +32,7 @@ namespace gpu {
 
 namespace alpa {
 namespace {
-void AddCallBackReleasingBuffer(se::Stream* stream, PyBuffer::object &buf_obj) {
+void AddCallBackReleasingBuffer(se::Stream *stream, PyBuffer::object &buf_obj) {
   // Holding the shared ptr of the buffer because we use it in an unsafe way.
   // This prevents XLA from freeing the buffer.
   std::shared_ptr<PjRtBuffer> pjrt_ref = buf_obj.buf()->shared_ptr_buffer();
@@ -178,8 +178,10 @@ Status CommGroup::NcclLocalAllGather(const AlpaNcclUid &key,
   CHECK_EQ(n_devices, buffers.size());
   CHECK_EQ(n_devices, local_start_positions.size());
 
-  TF_ASSIGN_OR_RETURN(ncclDataType_t dtype, ToNcclDataType(
-      buffers[0].buf()->buffer()->on_device_shape().element_type()));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t dtype,
+      ToNcclDataType(
+          buffers[0].buf()->buffer()->on_device_shape().element_type()));
   int dtype_size = SizeOfType(dtype);
   XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
   for (int i = 0; i < n_devices; ++i) {
@@ -213,8 +215,10 @@ Status CommGroup::NcclBroadcastPartialGPUs(
   CHECK_EQ(n_devices, buffers.size());
   CHECK_EQ(n_devices, local_start_positions.size());
 
-  TF_ASSIGN_OR_RETURN(ncclDataType_t dtype, ToNcclDataType(
-      buffers[0].buf()->buffer()->on_device_shape().element_type()));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t dtype,
+      ToNcclDataType(
+          buffers[0].buf()->buffer()->on_device_shape().element_type()));
   int dtype_size = SizeOfType(dtype);
 
   XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
@@ -253,8 +257,9 @@ Status CommGroup::NcclSend(const AlpaNcclUid &key, PyBuffer::object buffer,
                            bool use_default_stream) {
 #if XLA_ENABLE_XCCL
   const int device_id = local_ids[key][0];
-  TF_ASSIGN_OR_RETURN(ncclDataType_t dtype, ToNcclDataType(
-      buffer.buf()->buffer()->on_device_shape().element_type()));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t dtype,
+      ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type()));
   int dtype_size = SizeOfType(dtype);
   TF_ASSIGN_OR_RETURN(std::uintptr_t sendbuff,
                       buffer.buf()->UnsafeBufferPointer());
@@ -280,8 +285,9 @@ Status CommGroup::NcclRecv(const AlpaNcclUid &key, PyBuffer::object buffer,
                            bool use_default_stream) {
 #if XLA_ENABLE_XCCL
   const int device_id = local_ids[key][0];
-  TF_ASSIGN_OR_RETURN(ncclDataType_t dtype, ToNcclDataType(
-      buffer.buf()->buffer()->on_device_shape().element_type()));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t dtype,
+      ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type()));
   int dtype_size = SizeOfType(dtype);
   TF_ASSIGN_OR_RETURN(std::uintptr_t recvbuff,
                       buffer.buf()->UnsafeBufferPointer());
@@ -359,9 +365,7 @@ Status ComputationWaitEvents(const AlpaUuids &uuids,
 }
 
 // Event context management
-void ResetEventContext(std::shared_ptr<PyClient> client) {
-  ResetAlpaEvents();
-}
+void ResetEventContext(std::shared_ptr<PyClient> client) { ResetAlpaEvents(); }
 // Other functions
 std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid) {
   std::vector<char> nccl_uid_vec(sizeof(nccl_uid.internal), 0);

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -13,17 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// This file contains nccl api for alpa to use. 
+// This file contains nccl api for alpa to use.
 
 #ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_ALPA_NCCL_WRAPPER_H_
 #define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_ALPA_NCCL_WRAPPER_H_
-#ifdef XLA_ENABLE_XCCL
-#include <memory>
-
-#include "tensorflow/compiler/xla/status.h"
-#include "tensorflow/compiler/xla/statusor.h"
-#include "tensorflow/compiler/xla/xla_data.pb.h"
-
 // Common place for all collective thunks to include nccl/rccl headers.
 #if TENSORFLOW_USE_ROCM
 #include "rocm/include/rccl/rccl.h"
@@ -31,99 +24,86 @@ limitations under the License.
 #include "third_party/nccl/nccl.h"
 #endif
 
-#include "pybind11/pybind11.h"
-#include "pybind11/attr.h"
-#include "pybind11/cast.h"
-#include "pybind11/pytypes.h"
-
+#include "tensorflow/compiler/xla/pjrt/pjrt_stream_executor_client.h"
 #include "tensorflow/compiler/xla/python/py_buffer.h"
 #include "tensorflow/compiler/xla/python/py_client.h"
+#include "tensorflow/compiler/xla/service/gpu/nccl_utils.h"
+#include "tensorflow/compiler/xla/service/rendezvous.h"
 
 namespace xla {
 namespace gpu {
+namespace alpa {
+using AlpaNcclUid = std::vector<char>;
+using AlpaUuids = std::vector<int>;
 
-Status ncclResultToStatus(ncclResult_t s, const char* file, int64_t line,
-                          const char* expr);
+class CommGroup {
+ public:
+  CommGroup(std::shared_ptr<PyClient> backend);
+  // Communicator related functions:
+  Status NcclCreateCommunicators(int world_size,
+                                 const std::vector<int> &device_global_ranks,
+                                 const std::vector<int> &device_ids,
+                                 const AlpaNcclUid &nccl_uid_vec);
 
-#define XLA_CUDA_STATUS(expr) \
-  xla::gpu::ncclResultToStatus(expr, __FILE__, __LINE__, #expr)
+  Status NcclDestroyComms(const AlpaNcclUid &storage);
 
-#define XLA_CUDA_RETURN_IF_ERROR(expr) \
-  do {                                 \
-    Status s = XLA_CUDA_STATUS(expr);  \
-    if (!s.ok()) {                     \
-      return s;                        \
-    }                                  \
-  } while (0)
+  // Communication operations:
+  Status NcclLocalAllGather(const AlpaNcclUid &key,
+                            std::vector<PyBuffer::object> buffers,
+                            std::vector<uint> local_start_positions,
+                            uint global_start, uint n_elements,
+                            bool use_default_stream);
 
-#define XLA_CUDA_WARN_IF_ERROR(expr)  \
-  do {                                \
-    Status s = XLA_CUDA_STATUS(expr); \
-    if (!s.ok()) {                    \
-      LOG(ERROR) << s.ToString();     \
-    }                                 \
-  } while (0)
+  Status NcclBroadcastPartialGPUs(const AlpaNcclUid &key,
+                                  std::vector<PyBuffer::object> buffers,
+                                  std::vector<uint> local_start_positions,
+                                  uint n_elements, int root_rank,
+                                  bool use_recv_stream,
+                                  bool use_default_stream);
 
-ncclDataType_t ToNcclDataType(PrimitiveType element_type);
+  Status NcclSend(const AlpaNcclUid &key, PyBuffer::object buffer, uint start,
+                  uint n_elements, int peer_p2p_rank, bool use_default_stream);
 
-int SizeOfType(ncclDataType_t element_type);
+  Status NcclRecv(const AlpaNcclUid &key, PyBuffer::object buffer, uint start,
+                  uint n_elements, int peer_p2p_rank, bool use_default_stream);
 
-class NcclCommStorage {
-  public:
-    std::vector<ncclComm_t> comms;
-    std::vector<cudaStream_t> streams;
+  // Sync functions:
+  Status CommunicatorRecordEvents(const AlpaUuids &uuids, int num_devices,
+                                 bool is_send);
+
+  Status CommunicatorWaitEvents(const AlpaUuids &uuids, int num_devices,
+                                bool is_send);
+
+  void CommWaitCompute(bool is_send, bool is_compute, int device_id);
+
+  void ComputeWaitComm(bool is_send, bool is_compute, int device_id);
+
+ private:
+  std::vector<std::unique_ptr<se::Stream>> send_streams, recv_streams;
+  ThreadSafeMap<std::pair<AlpaNcclUid, int>, NcclComm> comm_map;
+  absl::flat_hash_map<AlpaNcclUid, std::vector<int>> local_ids;
+
+  std::vector<se::StreamExecutor *> executors;
+  PjRtStreamExecutorClient *client;
 };
 
-StatusOr<std::shared_ptr<NcclCommStorage>> NcclInitCommunicator(std::vector<int> devices_vec, bool nccl_use_multistream);
+// We add them here rather than alpa_events to avoid circular deps in Bazel:
+// alpa_events > done_event_thunk > executable > client >
+// ComputationWaitEvents
+Status ComputationWaitEvents(const AlpaUuids &uuids,
+                             std::shared_ptr<PyClient> client);
 
-Status NcclLocalAllGather(const NcclCommStorage &storage, 
-                          std::vector<PyBuffer::object> buffers, 
-                          std::vector<uint> local_start_positions, 
-                          uint global_start, 
-                          uint n_elements);
-
-Status NcclDestroyComms(NcclCommStorage &storage);
-
-Status NcclBroadcastPartialGPUs(const NcclCommStorage &storage, 
-                                std::vector<PyBuffer::object> buffers, 
-                                std::vector<uint> local_start_positions, 
-                                uint n_elements, 
-                                int root_rank);
-
-Status NcclSend(const NcclCommStorage &storage,
-                PyBuffer::object buffer,
-                uint start,
-                uint n_elements, 
-                int peer_p2p_rank);
-
-Status NcclRecv(const NcclCommStorage &storage,
-                PyBuffer::object buffer,
-                uint start,
-                uint n_elements,
-                int peer_p2p_rank);
-
-std::vector<char> NcclUidSerialize(ncclUniqueId nccl_uid);
-
+// Event context management
+void ResetEventContext(std::shared_ptr<PyClient> client);
+// Other functions:
 ncclUniqueId NcclUidDeserialize(std::vector<char> nccl_uid_chars);
 
 StatusOr<std::vector<char>> NcclGetUniqueId();
 
 StatusOr<int> NcclGetVersion();
 
-StatusOr<std::shared_ptr<NcclCommStorage>> NcclCreateCommunicators(int world_size,
-                                                                   std::vector<int> devices_global_rank,
-                                                                   std::vector<int> devices_ids,
-                                                                   std::vector<char> nccl_uid,
-                                                                   bool nccl_use_multistream);
-
-StatusOr<std::vector<std::uintptr_t>> NcclCreateCommunicatorsNoStream(
-    int world_size, std::vector<int> devices_global_rank,
-    std::vector<int> devices_ids, std::vector<int8_t> nccl_uid_vec);
-
 StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer);
-
-
+}  // namespace alpa
 }  // namespace gpu
 }  // namespace xla
-#endif // XLA_ENABLE_XCCL
 #endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_ALPA_NCCL_WRAPPER_H_

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -69,7 +69,7 @@ class CommGroup {
 
   // Sync functions:
   Status CommunicatorRecordEvents(const AlpaUuids &uuids, int num_devices,
-                                 bool is_send);
+                                  bool is_send);
 
   Status CommunicatorWaitEvents(const AlpaUuids &uuids, int num_devices,
                                 bool is_send);

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -33,7 +33,7 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 namespace alpa {
-using AlpaNcclUid = std::vector<char>;
+using AlpaNcclUid = std::vector<int8_t>;
 using AlpaUuids = std::vector<int>;
 
 class CommGroup {
@@ -96,9 +96,9 @@ Status ComputationWaitEvents(const AlpaUuids &uuids,
 // Event context management
 void ResetEventContext(std::shared_ptr<PyClient> client);
 // Other functions:
-ncclUniqueId NcclUidDeserialize(std::vector<char> nccl_uid_chars);
+ncclUniqueId NcclUidDeserialize(const AlpaNcclUid& nccl_uid_chars);
 
-StatusOr<std::vector<char>> NcclGetUniqueId();
+StatusOr<AlpaNcclUid> NcclGetUniqueId();
 
 StatusOr<int> NcclGetVersion();
 

--- a/tensorflow/compiler/xla/service/gpu/done_event_insertion.cc
+++ b/tensorflow/compiler/xla/service/gpu/done_event_insertion.cc
@@ -39,8 +39,8 @@ Status AddDoneEvent(HloInstruction* inst, size_t index, HloInstruction* root) {
 };  // namespace
 
 StatusOr<bool> HloDoneInsertion::Run(
-      HloModule* module,
-      const absl::flat_hash_set<absl::string_view>& execution_threads) {
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
 
   HloComputation* entry = module->entry_computation();

--- a/tensorflow/compiler/xla/service/gpu/done_event_insertion.cc
+++ b/tensorflow/compiler/xla/service/gpu/done_event_insertion.cc
@@ -1,0 +1,58 @@
+#include "tensorflow/compiler/xla/service/gpu/done_event_insertion.h"
+
+#include "tensorflow/compiler/xla/service/hlo_casting_utils.h"
+#include "tensorflow/compiler/xla/service/hlo_instruction.h"
+#include "tensorflow/compiler/xla/service/hlo_instructions.h"
+#include "tensorflow/compiler/xla/service/hlo_opcode.h"
+
+namespace xla {
+namespace {
+const char* const kDoneEvent = "__builtin$DoneEvent";
+// An element makes the liveness analysis lift the kernel as early as possible.
+const Shape DummyShape = ShapeUtil::MakeScalarShape(S32);
+
+Status AddDoneEvent(HloInstruction* inst, size_t index, HloInstruction* root) {
+  if (inst->opcode() == HloOpcode::kBitcast) {
+    for (HloInstruction* op : inst->mutable_operands()) {
+      TF_RETURN_IF_ERROR(AddDoneEvent(op, index, root));
+    }
+  } else if (inst->opcode() == HloOpcode::kGetTupleElement) {
+    HloInstruction* tuple = inst->mutable_operand(0);
+    if (tuple->opcode() == HloOpcode::kTuple) {
+      TF_RETURN_IF_ERROR(AddDoneEvent(
+          tuple->mutable_operand(inst->tuple_index()), index, root));
+    } else {
+      // Instructions like fusion generates a tuple
+      TF_RETURN_IF_ERROR(AddDoneEvent(inst->mutable_operand(0), index, root));
+    }
+  } else {
+    auto done_event = Cast<HloCustomCallInstruction>(
+        inst->parent()->AddInstruction(HloInstruction::CreateCustomCall(
+            DummyShape, {inst}, kDoneEvent, std::to_string(index))));
+    done_event->set_custom_call_has_side_effect(true);
+    if (root != inst) {
+      TF_RETURN_IF_ERROR(done_event->AddControlDependencyTo(root));
+    }
+  }
+  return Status::OK();
+}
+};  // namespace
+
+StatusOr<bool> HloDoneInsertion::Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool changed = false;
+
+  HloComputation* entry = module->entry_computation();
+  HloInstruction* root = entry->root_instruction();
+
+  if (root->opcode() == HloOpcode::kTuple) {
+    for (size_t i = 0; i < root->operand_count(); ++i) {
+      TF_RETURN_IF_ERROR(AddDoneEvent(root->mutable_operand(i), i, root));
+    }
+  } else {
+    TF_RETURN_IF_ERROR(AddDoneEvent(root, 0, root));
+  }
+  return changed;
+}
+};  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/done_event_insertion.h
+++ b/tensorflow/compiler/xla/service/gpu/done_event_insertion.h
@@ -1,0 +1,24 @@
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_HLO_DONE_EVENT_INSERTION_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_HLO_DONE_EVENT_INSERTION_H_
+
+#include "tensorflow/compiler/xla/service/hlo_pass_interface.h"
+
+namespace xla {
+class HloDoneInsertion : public HloModulePass {
+ public:
+  using ShapeSizeFunction = std::function<int64_t(const Shape&)>;
+  HloDoneInsertion() = default;
+
+  ~HloDoneInsertion() override = default;
+
+  absl::string_view name() const override { return "done-Insertion"; }
+
+  StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+};
+
+};  // namespace xla
+
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_HLO_DONE_EVENT_INSERTION_H_

--- a/tensorflow/compiler/xla/service/gpu/done_event_insertion.h
+++ b/tensorflow/compiler/xla/service/gpu/done_event_insertion.h
@@ -16,7 +16,6 @@ class HloDoneInsertion : public HloModulePass {
   StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
-
 };
 
 };  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/done_event_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/done_event_thunk.cc
@@ -1,0 +1,37 @@
+#include "tensorflow/compiler/xla/service/gpu/done_event_thunk.h"
+
+#include "tensorflow/compiler/xla/service/gpu/gpu_executable.h"
+
+namespace xla {
+namespace gpu {
+
+DoneEventThunk::DoneEventThunk(ThunkInfo thunk_info, size_t index)
+    : Thunk(Kind::kDoneEvent, thunk_info), output_index(index) {}
+
+Status DoneEventThunk::Initialize(const GpuExecutable& executable,
+                                  se::StreamExecutor* executor) {
+  if (executor->device_ordinal() == 0) {
+    event_stats = GetEventStats(output_index);
+  }
+  return OkStatus();
+}
+
+Status DoneEventThunk::ExecuteOnStream(const ExecuteParams& params) {
+  se::Stream& stream = *params.stream;
+  int device_ordinal = stream.parent()->device_ordinal();
+  if (device_ordinal == 0) {
+    absl::MutexLock lock(&mu_);
+    cur_run_id = params.nccl_params.run_id;
+  } else {
+    absl::MutexLock lock(&mu_);
+    auto run_id_match = [&]() {return params.nccl_params.run_id == cur_run_id;};
+    mu_.Await(absl::Condition(&run_id_match));
+  }
+  se::Event* done_event =
+      event_stats->RecordEvent(device_ordinal, stream.parent());
+  TF_RET_CHECK(done_event->Init());
+  stream.ThenRecordEvent(done_event);
+  return OkStatus();
+}
+};  // namespace gpu
+};  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/done_event_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/done_event_thunk.cc
@@ -24,7 +24,9 @@ Status DoneEventThunk::ExecuteOnStream(const ExecuteParams& params) {
     cur_run_id = params.nccl_params.run_id;
   } else {
     absl::MutexLock lock(&mu_);
-    auto run_id_match = [&]() {return params.nccl_params.run_id == cur_run_id;};
+    auto run_id_match = [&]() {
+      return params.nccl_params.run_id == cur_run_id;
+    };
     mu_.Await(absl::Condition(&run_id_match));
   }
   se::Event* done_event =

--- a/tensorflow/compiler/xla/service/gpu/done_event_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/done_event_thunk.h
@@ -1,0 +1,28 @@
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_DONE_EVENT_THUNK_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_DONE_EVENT_THUNK_H_
+
+#include "tensorflow/compiler/xla/service/gpu/alpa_events.h"
+#include "tensorflow/compiler/xla/service/gpu/thunk.h"
+
+namespace xla {
+namespace gpu {
+// Thunk to record an early done of a buffer
+class DoneEventThunk : public Thunk {
+ public:
+  DoneEventThunk(ThunkInfo thunk_info, size_t index);
+
+  Status Initialize(const GpuExecutable& executable,
+                    se::StreamExecutor* executor) override;
+
+  Status ExecuteOnStream(const ExecuteParams& params) override;
+
+ private:
+  const size_t output_index;
+  std::shared_ptr<DoneEventStats> event_stats;
+  absl::Mutex mu_;
+  RunId cur_run_id ABSL_GUARDED_BY(mu_);
+};
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_DONE_EVENT_THUNK_H_

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -202,6 +202,7 @@ limitations under the License.
 #include "tensorflow/tsl/util/env_var.h"
 
 // Added by Alpa
+#include "tensorflow/compiler/xla/service/gpu/done_event_insertion.h"
 #include "tensorflow/compiler/xla/service/pass_context.h"
 
 namespace xla {
@@ -703,6 +704,11 @@ Status GpuCompiler::OptimizeHloModule(
     TF_RETURN_IF_ERROR(pipeline.Run(hlo_module).status());
   }
 
+  if (pass_context::GetBool("done-event::enable", false)) {
+    HloPassPipeline pipeline("done event insertion");
+    pipeline.AddPass<HloDoneInsertion>();
+    TF_RETURN_IF_ERROR(pipeline.Run(hlo_module).status());
+  }
   return OkStatus();
 }
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -147,7 +147,6 @@ const char* const kBuiltinCrossMeshAllReduceTarget =
     "__builtin$CrossMeshAllReduce";
 const char* const kBuiltinDoneEventTarget = "__builtin$DoneEvent";
 
-
 bool IsCustomCallToCusolver(const HloInstruction& hlo) {
   if (hlo.opcode() != HloOpcode::kCustomCall) {
     return false;

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -145,6 +145,8 @@ const char* const kCusolverCholeskyCallTarget = "__cusolver$cholesky";
 const char* const kBuiltinMemZeroTarget = "__builtin$MemZero";
 const char* const kBuiltinCrossMeshAllReduceTarget =
     "__builtin$CrossMeshAllReduce";
+const char* const kBuiltinDoneEventTarget = "__builtin$DoneEvent";
+
 
 bool IsCustomCallToCusolver(const HloInstruction& hlo) {
   if (hlo.opcode() != HloOpcode::kCustomCall) {

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -72,6 +72,7 @@ extern const char* const kCusolverCholeskyCallTarget;
 // Added by Alpa
 extern const char* const kBuiltinMemZeroTarget;
 extern const char* const kBuiltinCrossMeshAllReduceTarget;
+extern const char* const kBuiltinDoneEventTarget;
 
 // Returns true if either the dimensions being reduced or the dimensions being
 // kept are contiguous in the input of the reduce instruction.

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -790,6 +790,7 @@ class IrEmitterUnnested : public IrEmitter {
 
   // Added by Alpa
   Status EmitMemZeroThunk(mlir::Operation* op);
+  Status EmitDoneEventThunk(mlir::Operation* op);
   Status EmitCrossMeshAllReduceTarget(mlir::Operation* op);
   Status EmitRngGetAndUpdateStateThunk(mlir::Operation* op);
   using Slices = std::vector<CustomCallThunk::OptionalSlice>;

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
@@ -472,14 +472,31 @@ Status RunReduceScatter(ReductionKind reduction_kind,
 std::vector<std::unique_ptr<NcclComm>> nccl_comms;
 
 // FIXME(yonghao): support multiple groups of cross mesh nccl comms with keys
-void SetCrossMeshCommunicators(const std::vector<std::uintptr_t>& comms,
-                               const std::string& group_keys) {
-  nccl_comms.clear();
-  nccl_comms.reserve(comms.size());
-  for (std::uintptr_t comm : comms) {
-    nccl_comms.emplace_back(
-        std::make_unique<NcclComm>(reinterpret_cast<ncclComm_t>(comm)));
+// by recording the uuid vec into the thunk and directly refer to the CommGroup
+// from the thunk
+Status CreateCrossMeshCommunicator(
+    int world_size, const std::vector<int> &device_global_ranks,
+    int num_device, const std::vector<char> &nccl_uid_vec) {
+#if XLA_ENABLE_XCCL
+  CHECK_EQ(num_device, device_global_ranks.size());
+  ncclUniqueId nccl_uid;
+  CHECK_EQ(sizeof(nccl_uid.internal), nccl_uid_vec.size());
+  memcpy(&nccl_uid.internal, nccl_uid_vec.data(), sizeof(nccl_uid.internal));
+
+  // Create Communicators
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
+  for (int device_id = 0; device_id < num_device; device_id++) {
+    cudaSetDevice(device_id);
+    int rank = device_global_ranks[device_id];
+    nccl_comms[device_id] = std::move(std::make_unique<NcclComm>());
+    NcclComm::Lock comm = nccl_comms[device_id]->Acquire();
+    XLA_CUDA_RETURN_IF_ERROR(
+        ncclCommInitRank(comm.get(), world_size, nccl_uid, rank));
   }
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
 }
 
 NcclAllReduceConfig GetCrossMeshNcclAllReduceConfig(

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
@@ -157,8 +157,10 @@ class CrossMeshNcclAllReduceThunk : public Thunk {
   bool first_call_to_execute_ = true;
 };
 
-void SetCrossMeshCommunicators(const std::vector<std::uintptr_t>& comms,
-                               const std::string& group_keys);
+Status CreateCrossMeshCommunicator(int world_size,
+                                   const std::vector<int>& device_global_ranks,
+                                   int num_device,
+                                   const std::vector<char>& nccl_uid_vec);
 
 }  // namespace gpu
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
@@ -160,7 +160,7 @@ class CrossMeshNcclAllReduceThunk : public Thunk {
 Status CreateCrossMeshCommunicator(int world_size,
                                    const std::vector<int>& device_global_ranks,
                                    int num_device,
-                                   const std::vector<char>& nccl_uid_vec);
+                                   const std::vector<int8_t>& nccl_uid_vec);
 
 }  // namespace gpu
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/nccl_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_utils.h
@@ -113,7 +113,6 @@ TSL_LIB_GTL_DEFINE_INT_TYPE(OpId, int64_t);
 
 struct NcclComm : public Lockable<ncclComm_t> {
   NcclComm() : Lockable(nullptr) {}
-  NcclComm(ncclComm_t comm) : Lockable(comm) {}  // Added by Alpa
 };
 
 StatusOr<NcclComm::Lock> AcquireNcclComm(

--- a/tensorflow/compiler/xla/service/gpu/thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/thunk.h
@@ -72,6 +72,7 @@ class Thunk {
     kTriangularSolve,
     kWhile,
     // Added by Alpa
+    kDoneEvent,
     kRngGetAndUpdateState,
   };
 


### PR DESCRIPTION
Initially, this PR is only to add `HloDoneInsertion` pass and `DoneEventThunk` correspondingly. Later, we change the goal of this PR:

- Add event manager to synchronize SPMD computations and cross-mesh communication for pipeline parallel. (`alpa_event.h`, `alpa_event.cc`)
  - For SPMD computation, we add `HloDoneInsertion`(`done_event_insertion.h`) pass to inject `DoneEventThunk`s(`done_event_thunk.h`) in the computational graph. This enables more precise arrangement. For example, in U-Net, outputs of layer 0 can be sent to the last layer during the computation of layer 1;
  - For communication, we provide with apis which add an event on each communication stream. Although the cross-mesh resharding is not SPMD, we add communication-computation synchronization only before and after communicating a whole tensor, which is made of shards on all devices;
  - We also provide with APIs to synchronize two streams. This is for sending non-continuous buffers, where we have to call XLA to tile tensors.
- Refactor `alpa_nccl_wrapper`: we create a class on c++ side, which provides apis very similiar as the `NcclGroup` class in Alpa's Python code (`alpa_nccl_wrapper.h`)