### PR TITLE
[Fix] Fix various bugs for gradient accumulation and reduce-scatter

### DIFF
--- a/tensorflow/compiler/xla/python/xla_compiler.cc
+++ b/tensorflow/compiler/xla/python/xla_compiler.cc
@@ -811,8 +811,7 @@ void BuildXlaCompilerSubmodule(py::module& m) {
   m.def("estimate_hlo_module_cost", &gpu::EstimateHloModuleCost);
   m.def("set_hlo_module_output_shardings", &spmd::SetHloModuleOutputShardings);
   m.def("set_hlo_module_input_shardings", &spmd::SetHloModuleInputShardings);
-  m.def("get_grad_sync_channel_ids", &spmd::GetGradSyncChannelIds,
-        py::arg("module"), py::arg("grad_idx") = absl::nullopt);
+  m.def("get_grad_sync_channel_ids", &spmd::GetGradSyncChannelIds);
 
   m.def("run_auto_sharding", 
         [](HloModule* hlo_module, const CompileOptions& options) {

--- a/tensorflow/compiler/xla/python/xla_compiler.cc
+++ b/tensorflow/compiler/xla/python/xla_compiler.cc
@@ -812,6 +812,7 @@ void BuildXlaCompilerSubmodule(py::module& m) {
   m.def("set_hlo_module_output_shardings", &spmd::SetHloModuleOutputShardings);
   m.def("set_hlo_module_input_shardings", &spmd::SetHloModuleInputShardings);
   m.def("get_grad_sync_channel_ids", &spmd::GetGradSyncChannelIds);
+  m.def("get_alpa_jaxlib_version", [] { return "0.1.0"; });
 
   m.def("run_auto_sharding", 
         [](HloModule* hlo_module, const CompileOptions& options) {

--- a/tensorflow/compiler/xla/service/BUILD
+++ b/tensorflow/compiler/xla/service/BUILD
@@ -2628,6 +2628,7 @@ cc_library(
         "//tensorflow/compiler/xla:status_macros",
         "//tensorflow/compiler/xla:statusor",
         "//tensorflow/compiler/xla:xla_data_proto_cc",
+        "//tensorflow/compiler/xla/service/spmd:grad_acc_rewrite",
         "//tensorflow/core:lib",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/tensorflow/compiler/xla/service/all_reduce_combiner.cc
+++ b/tensorflow/compiler/xla/service/all_reduce_combiner.cc
@@ -35,8 +35,8 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/hlo_opcode.h"
 #include "tensorflow/compiler/xla/service/hlo_query.h"
 #include "tensorflow/compiler/xla/service/hlo_reachability.h"
-#include "tensorflow/compiler/xla/service/pass_context.h"
 #include "tensorflow/compiler/xla/service/shape_inference.h"
+#include "tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.h"
 #include "tensorflow/compiler/xla/shape_util.h"
 #include "tensorflow/compiler/xla/status_macros.h"
 #include "tensorflow/compiler/xla/xla_data.pb.h"
@@ -87,6 +87,9 @@ Status CombineAllReduces(absl::Span<HloInstruction* const> to_combine) {
       /*constrain_layout=*/false, to_combine.front()->channel_id(),
       Cast<HloAllReduceInstruction>(to_combine.front())
           ->use_global_device_ids()));
+  if (to_combine.front()->metadata().op_name() == spmd::kSkippableAllReduce) {
+    combined->set_metadata_op_name(spmd::kSkippableAllReduce);
+  }
 
   // We have to propagate the sharding manually because Domain instructions are
   // not guaranteed to preserve it for side effecting instructions.
@@ -105,85 +108,17 @@ Status CombineAllReduces(absl::Span<HloInstruction* const> to_combine) {
   }
   return Status::OK();
 }
-
-// Combines the elements of to_combine into a single AllReduce op. All
-// entries in to_combine must be AllReduce ops with exactly one operand
-// and the same reduction operation.
-// Different from the above implementation. This implementation do
-// the combined all-reduce in a continous buffer.
-Status CombineAllReducesContinuousBuffer(absl::Span<HloInstruction* const> to_combine) {
-  if (to_combine.size() < 2) {
-    return Status::OK();
-  }
-  VLOG(1) << "Combined " << to_combine.size() << " CRS ops";
-
-  HloComputation& computation = *to_combine.back()->parent();
-  HloComputation* reduction = to_combine[0]->to_apply();
-  const HloOpcode type = reduction->root_instruction()->opcode();
-
-  // Create a single bigger AllReduce of the operands of the smaller
-  // AllReduces.
-  std::vector<HloInstruction*> operands;
-  VLOG(1) << "Combining set";
-  for (HloInstruction* hlo : to_combine) {
-    VLOG(1) << "Set element: " << hlo->ToString();
-    TF_RET_CHECK(hlo->opcode() == HloOpcode::kAllReduce);
-    TF_RET_CHECK(hlo->operands().size() == 1);
-    TF_RET_CHECK(hlo->to_apply() == reduction ||
-                 (hlo->to_apply()->instruction_count() == 3 &&
-                  hlo->to_apply()->num_parameters() == 2 &&
-                  hlo->to_apply()->root_instruction()->opcode() == type));
-    TF_RET_CHECK(hlo->shape().IsArray());
-    for (HloInstruction* operand : hlo->operands()) {
-      operands.push_back(operand);
-    }
-  }
-
-  // Flatten and concatenate all buffers
-  std::vector<HloInstruction*> flattens;
-  int64_t total_count = 0;
-  for (HloInstruction* hlo : operands) {
-    int64_t count = ShapeUtil::ElementsIn(hlo->shape());
-	Shape shape = ShapeUtil::MakeShape(hlo->shape().element_type(), {count});
-    flattens.push_back(computation.AddInstruction(
-      HloInstruction::CreateReshape(shape, hlo)
-    ));
-    total_count += count;
-  }
-  Shape flatten_shape = ShapeUtil::MakeShape(flattens[0]->shape().element_type(), {total_count});
-  HloInstruction* concat = computation.AddInstruction(
-    HloInstruction::CreateConcatenate(flatten_shape, flattens, /*dimension=*/0));
-
-  // Do a combined all-reduce
-  HloInstruction* combined = computation.AddInstruction(HloInstruction::CreateAllReduce(
-      flatten_shape, {concat}, reduction,
-      to_combine.front()->replica_groups(),
-      /*constrain_layout=*/false, to_combine.front()->channel_id(),
-      Cast<HloAllReduceInstruction>(to_combine.front())->use_global_device_ids()));
-
-  // Slice results and reshape to their origial shapes
-  int64_t pt = 0;
-  for (int64_t i = 0; i < to_combine.size(); ++i) {
-    int64_t count = ShapeUtil::ElementsIn(flattens[i]->shape());
-    HloInstruction* res = computation.AddInstruction(
-      HloInstruction::CreateSlice(
-       flattens[i]->shape(), combined,
-       /*start_indices=*/{pt}, /*limit_indices=*/{pt + count}, /*strides=*/{1}));
-    auto replace_with = HloInstruction::CreateReshape(
-        to_combine[i]->shape(), res);
-    TF_RETURN_IF_ERROR(computation.ReplaceWithNewInstruction(
-        to_combine[i], std::move(replace_with)));
-    pt += count;
-  }
-  return Status::OK();
-}
-
 }  // namespace
 
 AllReduceCombiner::AllReduceCombiner(int64_t combine_threshold_in_bytes,
                                      int64_t combine_threshold_count)
     : combine_threshold_in_bytes_(combine_threshold_in_bytes),
       combine_threshold_count_(combine_threshold_count) {}
+
+// Add a new boolean field to the original AllReduceKey.
+// This field indicates whether the all-reduce is a skippable
+// all-reduce for gradient accumulation.
+using AllReduceKeyWithSkip = std::tuple<AllReduceKey, bool>;
 
 StatusOr<bool> AllReduceCombiner::Run(HloModule* module) {
   VLOG(1) << "Running AllReduceCombiner with threshold of "
@@ -206,19 +141,23 @@ StatusOr<bool> AllReduceCombiner::Run(HloModule* module) {
 
     auto key_fn =
         [&domain_map](
-            const HloInstruction* instruction) -> absl::optional<AllReduceKey> {
+            const HloInstruction* instruction) -> absl::optional<AllReduceKeyWithSkip> {
       if (instruction->opcode() != HloOpcode::kAllReduce) {
         return absl::nullopt;
       }
-      return GetAllReduceKey(instruction, domain_map.get());
+      auto old_key = GetAllReduceKey(instruction, domain_map.get());
+      if (!old_key.has_value()) {
+        return absl::nullopt;
+      }
+      return AllReduceKeyWithSkip{
+        *old_key,
+        instruction->metadata().op_name() == spmd::kSkippableAllReduce};
     };
 
     TF_ASSIGN_OR_RETURN(
         bool computation_changed,
-        CombineInstructionsByKey<AllReduceKey>(
-            computation, key_fn,
-            pass_context::GetBool("combiner::use_continuous_buffer", false) ?
-              &CombineAllReducesContinuousBuffer: &CombineAllReduces,
+        CombineInstructionsByKey<AllReduceKeyWithSkip>(
+            computation, key_fn, &CombineAllReduces,
             combine_threshold_in_bytes_, combine_threshold_count_));
     changed |= computation_changed;
   }

--- a/tensorflow/compiler/xla/service/all_reduce_contiguous.cc
+++ b/tensorflow/compiler/xla/service/all_reduce_contiguous.cc
@@ -59,6 +59,7 @@ Status ReplaceWithContiguousAllReduce(HloAllReduceInstruction* all_reduce) {
           all_reduce->replica_groups(),
           /*constrain_layout=*/false, all_reduce->channel_id(),
           all_reduce->use_global_device_ids()));
+  new_all_reduce->set_metadata_op_name(all_reduce->metadata().op_name());
 
   // Slice from all-reduce result and bitcast back to the original shapes.
   std::vector<HloInstruction*> outputs;

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -602,7 +602,7 @@ Status GpuCompiler::OptimizeHloModule(
         pass_context::GetInt("combiner::all_reduce_threshold", 30 * 1024 * 1024),
         /*combine_threshold_count=*/512);
 
-    if (debug_options.xla_gpu_all_reduce_contiguous()) {
+    if (true || debug_options.xla_gpu_all_reduce_contiguous()) {
       pipeline.AddPass<AllReduceContiguous>();
     }
 

--- a/tensorflow/compiler/xla/service/spmd/BUILD
+++ b/tensorflow/compiler/xla/service/spmd/BUILD
@@ -248,6 +248,7 @@ cc_library(
         ":stateful_rng_spmd_partitioner",
         "//tensorflow/compiler/xla/pjrt:pjrt_client",
         "//tensorflow/compiler/xla/service:algebraic_simplifier",
+        "//tensorflow/compiler/xla/service:all_reduce_reassociate",
         "//tensorflow/compiler/xla/service:call_inliner",
         "//tensorflow/compiler/xla/service:conditional_canonicalizer",
         "//tensorflow/compiler/xla/service:conditional_simplifier",

--- a/tensorflow/compiler/xla/service/spmd/BUILD
+++ b/tensorflow/compiler/xla/service/spmd/BUILD
@@ -220,6 +220,7 @@ cc_library(
         "//tensorflow/compiler/xla/service:hlo",
         "//tensorflow/compiler/xla/service:hlo_pass",
         "//tensorflow/compiler/xla/service:pass_context",
+        "//tensorflow/compiler/xla/service/spmd:spmd_partitioner",
     ],
 )
 

--- a/tensorflow/compiler/xla/service/spmd/alpa_compile.cc
+++ b/tensorflow/compiler/xla/service/spmd/alpa_compile.cc
@@ -1,5 +1,6 @@
 #include "tensorflow/compiler/xla/service/spmd/alpa_compile.h"
 #include "tensorflow/compiler/xla/service/algebraic_simplifier.h"
+#include "tensorflow/compiler/xla/service/all_reduce_reassociate.h"
 #include "tensorflow/compiler/xla/service/call_inliner.h"
 #include "tensorflow/compiler/xla/service/conditional_canonicalizer.h"
 #include "tensorflow/compiler/xla/service/conditional_simplifier.h"
@@ -150,6 +151,7 @@ Status RunAutoShardingPass(HloModule* hlo_module,
       spmd_pipeline.AddPass<StatefulRngSpmdPartitioner>(
           num_partitions, hlo_module->config().replica_count());
       spmd_pipeline.AddPass<RedundantSliceEliminator>();
+      spmd_pipeline.AddPass<AllReduceReassociate>();
       spmd_pipeline.AddPass<GradAccRewrite>();
     } else {
       spmd_pipeline.AddPass<SliceAutoShardedStages>();
@@ -178,6 +180,7 @@ Status RunSpmdPartitionerPass(HloModule* hlo_module,
       spmd_pipeline.AddPass<StatefulRngSpmdPartitioner>(
           num_partitions, hlo_module->config().replica_count());
       spmd_pipeline.AddPass<RedundantSliceEliminator>();
+      spmd_pipeline.AddPass<AllReduceReassociate>();
       spmd_pipeline.AddPass<GradAccRewrite>();
     } else {
       // Remove redundant sharding ops when partition_count == 1.

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
@@ -880,8 +880,11 @@ BuildStrategyAndCost(const HloInstructionSequence& sequence,
 
             int operand_dim = dnums.offset_dims(i);
 
+            CHECK_LT(operand_dim, ins->operand(0)->shape().rank())
+                << "Does not support this kind of Gather.";
             CHECK_EQ(ins->shape().dimensions(operand_dim),
-                     ins->operand(0)->shape().dimensions(operand_dim));
+                     ins->operand(0)->shape().dimensions(operand_dim))
+                << "Does not support this kind of Gather.";
 
             std::vector<HloSharding> operand_specs{
                 Tile(ins->operand(0)->shape(), {operand_dim}, {j}, device_mesh),

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_util.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_util.cc
@@ -1188,11 +1188,11 @@ bool AllUsersAreReduce(const HloInstruction* inst) {
 }
 
 // Set sharding, and apply transpose if necessary.
-void SetShardingImpl(HloInstruction* to_split, const HloSharding& output_spec,
-                     const HloInstruction* ref_inst,
-                     const HloInstruction* shape_inst,
-                     const absl::flat_hash_set<const HloInstruction*>& transposed_set,
-                     absl::flat_hash_set<const HloInstruction*>& modified) {
+void SetShardingImpl(
+    HloInstruction* to_split, const HloSharding& output_spec,
+    const HloInstruction* ref_inst, const HloInstruction* shape_inst,
+    const absl::flat_hash_set<const HloInstruction*>& transposed_set,
+    absl::flat_hash_set<const HloInstruction*>& modified) {
   CHECK(!to_split->shape().IsTuple()) << to_split->ToString();
   modified.insert(to_split);
   if (transposed_set.count(to_split)) {
@@ -1201,7 +1201,8 @@ void SetShardingImpl(HloInstruction* to_split, const HloSharding& output_spec,
     to_split->set_sharding(hlo_sharding_util::TransposeSharding(
         output_spec, shape_inst->dimensions()));
   } else {
-    CHECK(DimensionsEqual(to_split->shape(), ref_inst->shape())) << to_split->ToString() << " VS. " << ref_inst->ToString();
+    CHECK(DimensionsEqual(to_split->shape(), ref_inst->shape()))
+        << to_split->ToString() << " VS. " << ref_inst->ToString();
     to_split->set_sharding(output_spec);
   }
 }
@@ -1306,8 +1307,8 @@ void FindReplicateSet(
     HloInstruction* cur, const AliasMap& alias_map, const CostGraph& cost_graph,
     const std::vector<int64_t>& s_val, const StrategyMap& strategy_map,
     const ShardingStrategy& strategy, const HloInstruction* output,
-    bool do_all_gather_after_backward,
-    HloInstruction*& transpose_inst, bool in_transpose_region,
+    bool do_all_gather_after_backward, HloInstruction*& transpose_inst,
+    bool in_transpose_region,
     absl::flat_hash_set<const HloInstruction*>& transposed_set,
     absl::flat_hash_set<HloInstruction*>& replicated_set,
     absl::flat_hash_set<HloInstruction*>& boundary_set,
@@ -1359,9 +1360,8 @@ void FindReplicateSet(
 
       FindReplicateSet(consumer, alias_map, cost_graph, s_val, strategy_map,
                        strategy, output, do_all_gather_after_backward,
-                       transpose_inst, in_transpose_region_tmp,
-                       transposed_set, replicated_set, boundary_set,
-                       consumer_set, visited);
+                       transpose_inst, in_transpose_region_tmp, transposed_set,
+                       replicated_set, boundary_set, consumer_set, visited);
     }
   }
 
@@ -1375,9 +1375,8 @@ void FindReplicateSet(
         DimensionsEqual(operand->shape(), cur->shape())) {
       FindReplicateSet(operand, alias_map, cost_graph, s_val, strategy_map,
                        strategy, output, do_all_gather_after_backward,
-                       transpose_inst, in_transpose_region,
-                       transposed_set, replicated_set, boundary_set,
-                       consumer_set, visited);
+                       transpose_inst, in_transpose_region, transposed_set,
+                       replicated_set, boundary_set, consumer_set, visited);
     }
   }
 }
@@ -1666,8 +1665,8 @@ void GenerateReduceScatter(const HloInstructionSequence& sequence,
       auto SetSharding = [&](HloInstruction* to_split,
                              const HloSharding& output_spec,
                              const HloInstruction* ref_inst) {
-        SetShardingImpl(to_split, output_spec, ref_inst,
-                        transpose_inst, transposed_set, modified);
+        SetShardingImpl(to_split, output_spec, ref_inst, transpose_inst,
+                        transposed_set, modified);
       };
 
       for (HloInstruction* to_split : replicated_set) {

--- a/tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.cc
+++ b/tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.cc
@@ -8,6 +8,22 @@
 namespace xla {
 namespace spmd {
 
+HloInstruction* GetAllReduce(HloInstruction* src) {
+  if (src->opcode() == HloOpcode::kAllReduce) {
+    return src;
+  } else if (src->opcode() == HloOpcode::kMultiply) {
+    HloInstruction* lhs = GetAllReduce(src->mutable_operand(0));
+    HloInstruction* rhs = GetAllReduce(src->mutable_operand(1));
+
+    if (lhs != nullptr && rhs == nullptr) {
+      return lhs;
+    } else if (lhs == nullptr && rhs != nullptr) {
+      return rhs;
+    }
+  }
+  return nullptr;
+}
+
 StatusOr<bool> GradAccRewrite::Run(HloModule* module) {
   if (!pass_context::GetBool("auto_sharding::rewrite_for_grad_acc", false)) {
     return false;
@@ -28,15 +44,22 @@ StatusOr<bool> GradAccRewrite::Run(HloModule* module) {
       continue;
     }
 
-    HloInstruction* allreduce_ins = add_ins->mutable_operand(1);
+    HloInstruction* allreduce_ins = GetAllReduce(add_ins->mutable_operand(1));
 
-    if (allreduce_ins->opcode() != HloOpcode::kAllReduce) {
+    if (allreduce_ins == nullptr || allreduce_ins->users().size() != 1) {
       continue;
     }
 
-    CHECK(allreduce_ins->operand_count() == 1);
+    CHECK_EQ(allreduce_ins->operand_count(), 1);
 
-    add_ins->ReplaceOperandWith(1, allreduce_ins->mutable_operand(0));
+    HloInstruction* allreduce_user = allreduce_ins->users().front();
+
+    for (size_t i = 0; i < allreduce_user->operand_count(); ++i) {
+      if (allreduce_user->operand(i) == allreduce_ins) {
+        allreduce_user->ReplaceOperandWith(i, allreduce_ins->mutable_operand(0));
+      }
+    }
+
     allreduce_ins->ReplaceOperandWith(0, add_ins);
     output_tuple->ReplaceOperandWith(i, allreduce_ins);
   }
@@ -48,19 +71,33 @@ StatusOr<bool> GradAccRewrite::Run(HloModule* module) {
   return true;
 }
 
-void DfsSearch(const HloInstruction* cur, absl::flat_hash_set<int>& ret) {
+void DfsSearch(const HloInstruction* cur,
+               absl::flat_hash_set<const HloInstruction*>& touch_set,
+               absl::flat_hash_set<const HloInstruction*>& allreduce_set) {
   switch (cur->opcode()) {
     case HloOpcode::kTuple:
     case HloOpcode::kSlice:
     case HloOpcode::kGetTupleElement:
+    case HloOpcode::kConvert:
+    case HloOpcode::kReshape:
     case HloOpcode::kBitcast: {
+      touch_set.insert(cur);
       for (size_t i = 0; i < cur->operand_count(); ++i) {
-        DfsSearch(cur->operand(i), ret);
+        DfsSearch(cur->operand(i), touch_set, allreduce_set);
+      }
+      break;
+    }
+    case HloOpcode::kFusion: {
+      // FIXME(lmzheng): we should check the instructions in the body
+      // to make sure they are compatible with gradient accumulation.
+      touch_set.insert(cur);
+      for (size_t i = 0; i < cur->operand_count(); ++i) {
+        DfsSearch(cur->operand(i), touch_set, allreduce_set);
       }
       break;
     }
     case HloOpcode::kAllReduce: {
-      ret.insert(cur->channel_id().value());
+      allreduce_set.insert(cur);
       break;
     }
     default:
@@ -70,22 +107,28 @@ void DfsSearch(const HloInstruction* cur, absl::flat_hash_set<int>& ret) {
 
 std::string GetGradSyncChannelIds(const HloModule* module,
                                   absl::optional<std::vector<int>> grad_idx) {
-  absl::flat_hash_set<int> channel_ids;
+  absl::flat_hash_set<const HloInstruction*> touch_set;
+  absl::flat_hash_set<const HloInstruction*> allreduce_set;
 
   HloInstruction* root = module->entry_computation()->root_instruction();
   if (grad_idx) {
     CHECK(root->opcode() == HloOpcode::kTuple ||
           root->opcode() == HloOpcode::kAllReduce) << "The root inst is not tuple";
     for (int idx : grad_idx.value()) {
-      DfsSearch(root->operand(idx), channel_ids);
+      DfsSearch(root->operand(idx), touch_set, allreduce_set);
     }
   } else {
-    DfsSearch(root, channel_ids);
+    DfsSearch(root, touch_set, allreduce_set);
   }
 
   std::string ret = ".";
-  for (auto x : channel_ids) {
-    ret += std::to_string(x) + ".";
+  for (auto inst : allreduce_set) {
+    for (auto user: inst->users()) {
+      CHECK(touch_set.count(user))
+        << "Invalid users of all-reduce in gradient accumulation. "
+        << user->ToString();
+    }
+    ret += std::to_string(inst->channel_id().value()) + ".";
   }
 
   return ret;

--- a/tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.cc
+++ b/tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.cc
@@ -111,6 +111,10 @@ std::string GetGradSyncChannelIds(const HloModule* module,
   absl::flat_hash_set<const HloInstruction*> touch_set;
   absl::flat_hash_set<const HloInstruction*> allreduce_set;
 
+  // std::cerr << "===== Enter GetGradSync =====" << std::endl;
+  // std::cerr << module->ToString();
+  // std::cerr << "=============================" << std::endl;
+
   HloInstruction* root = module->entry_computation()->root_instruction();
   touch_set.insert(root);
   if (grad_idx) {
@@ -127,9 +131,9 @@ std::string GetGradSyncChannelIds(const HloModule* module,
   std::string ret = ".";
   for (auto inst : allreduce_set) {
     for (auto user : inst->users()) {
-      CHECK(touch_set.count(user))
-          << "Invalid users of all-reduce in gradient accumulation. "
-          << user->ToString();
+      //CHECK(touch_set.count(user))
+      //    << "Invalid users of all-reduce in gradient accumulation. "
+      //    << user->ToString();
     }
     ret += std::to_string(inst->channel_id().value()) + ".";
   }

--- a/tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.cc
+++ b/tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.cc
@@ -56,7 +56,8 @@ StatusOr<bool> GradAccRewrite::Run(HloModule* module) {
 
     for (size_t i = 0; i < allreduce_user->operand_count(); ++i) {
       if (allreduce_user->operand(i) == allreduce_ins) {
-        allreduce_user->ReplaceOperandWith(i, allreduce_ins->mutable_operand(0));
+        allreduce_user->ReplaceOperandWith(i,
+                                           allreduce_ins->mutable_operand(0));
       }
     }
 
@@ -111,9 +112,11 @@ std::string GetGradSyncChannelIds(const HloModule* module,
   absl::flat_hash_set<const HloInstruction*> allreduce_set;
 
   HloInstruction* root = module->entry_computation()->root_instruction();
+  touch_set.insert(root);
   if (grad_idx) {
     CHECK(root->opcode() == HloOpcode::kTuple ||
-          root->opcode() == HloOpcode::kAllReduce) << "The root inst is not tuple";
+          root->opcode() == HloOpcode::kAllReduce)
+        << "The root inst is not tuple";
     for (int idx : grad_idx.value()) {
       DfsSearch(root->operand(idx), touch_set, allreduce_set);
     }
@@ -123,10 +126,10 @@ std::string GetGradSyncChannelIds(const HloModule* module,
 
   std::string ret = ".";
   for (auto inst : allreduce_set) {
-    for (auto user: inst->users()) {
+    for (auto user : inst->users()) {
       CHECK(touch_set.count(user))
-        << "Invalid users of all-reduce in gradient accumulation. "
-        << user->ToString();
+          << "Invalid users of all-reduce in gradient accumulation. "
+          << user->ToString();
     }
     ret += std::to_string(inst->channel_id().value()) + ".";
   }

--- a/tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.cc
+++ b/tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.cc
@@ -63,6 +63,7 @@ StatusOr<bool> GradAccRewrite::Run(HloModule* module) {
 
     allreduce_ins->ReplaceOperandWith(0, add_ins);
     output_tuple->ReplaceOperandWith(i, allreduce_ins);
+    allreduce_ins->set_metadata_op_name(kSkippableAllReduce);
   }
 
   // std::cerr << "===== Exit GradAccRewrite =====" << std::endl;
@@ -72,98 +73,13 @@ StatusOr<bool> GradAccRewrite::Run(HloModule* module) {
   return true;
 }
 
-bool IsCompatible(const HloComputation* computation) {
-  // Return whether the fused computation is compatible with
-  // gradient accumulation.
-  // Strictly checking this is non-trivial. Here, we only use
-  // a very simple while-list based method.
-  // FIXME(lmzheng): the condition is too loose and the result might
-  // be wrong.
-  for (const auto inst : computation->instructions()) {
-    switch (inst->opcode()) {
-      case HloOpcode::kParameter:
-      case HloOpcode::kConvert:
-      case HloOpcode::kReshape:
-      case HloOpcode::kBitcast:
-      case HloOpcode::kTranspose:
-      case HloOpcode::kConcatenate:
-      case HloOpcode::kSlice:
-      case HloOpcode::kAdd:
-      case HloOpcode::kGetTupleElement:
-      case HloOpcode::kTuple:
-        continue;
-      default:
-        return false;
-    }
-  }
-  return true;
-}
-
-void DfsSearch(const HloInstruction* cur,
-               absl::flat_hash_set<const HloInstruction*>& touch_set,
-               absl::flat_hash_set<const HloInstruction*>& allreduce_set) {
-  switch (cur->opcode()) {
-    case HloOpcode::kTuple:
-    case HloOpcode::kSlice:
-    case HloOpcode::kGetTupleElement:
-    case HloOpcode::kConvert:
-    case HloOpcode::kReshape:
-    case HloOpcode::kBitcast: {
-      touch_set.insert(cur);
-      for (size_t i = 0; i < cur->operand_count(); ++i) {
-        DfsSearch(cur->operand(i), touch_set, allreduce_set);
-      }
-      break;
-    }
-    case HloOpcode::kFusion: {
-      if (!IsCompatible(cur->fused_instructions_computation())) {
-        break;
-      }
-      touch_set.insert(cur);
-      for (size_t i = 0; i < cur->operand_count(); ++i) {
-        DfsSearch(cur->operand(i), touch_set, allreduce_set);
-      }
-      break;
-    }
-    case HloOpcode::kAllReduce: {
-      allreduce_set.insert(cur);
-      break;
-    }
-    default:
-      break;
-  }
-}
-
-std::string GetGradSyncChannelIds(const HloModule* module,
-                                  absl::optional<std::vector<int>> grad_idx) {
-  absl::flat_hash_set<const HloInstruction*> touch_set;
-  absl::flat_hash_set<const HloInstruction*> allreduce_set;
-
-  // std::cerr << "===== Enter GetGradSync =====" << std::endl;
-  // std::cerr << module->ToString();
-  // std::cerr << "=============================" << std::endl;
-
-  HloInstruction* root = module->entry_computation()->root_instruction();
-  touch_set.insert(root);
-  if (grad_idx) {
-    CHECK(root->opcode() == HloOpcode::kTuple ||
-          root->opcode() == HloOpcode::kAllReduce)
-        << "The root inst is not tuple";
-    for (int idx : grad_idx.value()) {
-      DfsSearch(root->operand(idx), touch_set, allreduce_set);
-    }
-  } else {
-    DfsSearch(root, touch_set, allreduce_set);
-  }
-
+std::string GetGradSyncChannelIds(const HloModule* module) {
   std::string ret = ".";
-  for (auto inst : allreduce_set) {
-    for (auto user : inst->users()) {
-      CHECK(touch_set.count(user))
-          << "Invalid users of all-reduce in gradient accumulation. "
-          << user->ToString();
+  for (auto inst : module->entry_computation()->instructions()) {
+    if (inst->opcode() == HloOpcode::kAllReduce &&
+        inst->metadata().op_name() == kSkippableAllReduce) {
+      ret += std::to_string(inst->channel_id().value()) + ".";
     }
-    ret += std::to_string(inst->channel_id().value()) + ".";
   }
 
   return ret;

--- a/tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.h
+++ b/tensorflow/compiler/xla/service/spmd/grad_acc_rewrite.h
@@ -31,8 +31,9 @@ class GradAccRewrite : public HloModulePass {
   StatusOr<bool> Run(HloModule* module) override;
 };
 
-std::string GetGradSyncChannelIds(const HloModule* module,
-                                  absl::optional<std::vector<int>> grad_idx);
+std::string GetGradSyncChannelIds(const HloModule* module);
+
+const char* const kSkippableAllReduce = "grad_acc_skippable_all_reduce";
 
 }  // namespace spmd
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/spmd/slice_auto_sharded_stages.cc
+++ b/tensorflow/compiler/xla/service/spmd/slice_auto_sharded_stages.cc
@@ -92,7 +92,7 @@ std::unique_ptr<HloModule> CreateStageModule(
   for (auto ins : stage_instructions) {
     CHECK_NE(ins->opcode(), HloOpcode::kParameter)
         << "All the inputs to a pipeline stage should be from the start "
-           "marker.";
+           "marker. " << ins->ToString();
     if (ins->opcode() == HloOpcode::kGetTupleElement &&
         ins->operand(0) == stage_start_instruction) {
       int64_t param_no = ins->tuple_index();


### PR DESCRIPTION
Fix some corner cases founded in a huggingface GPT example
- Use a new method for `get_grad_sync_channel_ids`. Now we do not guess which all-reduce should be skipped. Instead, we use op_metadata to tag every all-reduce we modified in the `GradAccRewrite` pass. This is very accurate and fixes the bug in https://github.com/alpa-projects/alpa/issues/273
- Fix transpose in reduce-scatter
- Fix loss, shared embedding in gradient accumulation
