### PR TITLE
[Feature] Support cross mesh nccl allreduce

### DIFF
--- a/tensorflow/compiler/xla/python/xla.cc
+++ b/tensorflow/compiler/xla/python/xla.cc
@@ -552,6 +552,9 @@ PYBIND11_MODULE(xla_extension, m) {
         "nccl broadcast with only a subset of gpus in the host are involved");
   m.def("nccl_create_communicators", &gpu::NcclCreateCommunicators, 
         "nccl create communicators for multiple threads case");
+  m.def("nccl_create_communicators_no_stream",
+        &gpu::NcclCreateCommunicatorsNoStream,
+        "nccl create pure communicators");
   m.def("get_buffer_device_id", &gpu::GetBufferDeviceId, 
         "get the local device id for one pybuffer");
   m.def("nccl_recv", &gpu::NcclRecv, "nccl recv data");

--- a/tensorflow/compiler/xla/python/xla.cc
+++ b/tensorflow/compiler/xla/python/xla.cc
@@ -62,6 +62,7 @@ limitations under the License.
 #include "tensorflow/python/lib/core/bfloat16.h"
 #include "third_party/nccl/nccl.h"
 #include "tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h"
+#include "tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h"
 
 // TODO(phawkins): remove host_id properties after JAX is update to avoid them.
 
@@ -555,6 +556,8 @@ PYBIND11_MODULE(xla_extension, m) {
         "get the local device id for one pybuffer");
   m.def("nccl_recv", &gpu::NcclRecv, "nccl recv data");
   m.def("nccl_send", &gpu::NcclSend, "nccl send data");
+  m.def("set_cross_mesh_communicator", &gpu::SetCrossMeshCommunicators,
+        "set nccl communicators for cross mesh collective communication");
 
 }  // NOLINT(readability/fn_size)
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -116,6 +116,10 @@ StatusOr<std::shared_ptr<NcclCommStorage>> NcclCreateCommunicators(int world_siz
                                                                    std::vector<char> nccl_uid,
                                                                    bool nccl_use_multistream);
 
+StatusOr<std::vector<std::uintptr_t>> NcclCreateCommunicatorsNoStream(
+    int world_size, std::vector<int> devices_global_rank,
+    std::vector<int> devices_ids, std::vector<int8_t> nccl_uid_vec);
+
 StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer);
 
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -153,7 +153,8 @@ const char* const kBuiltinSwapOutTarget = "__builtin$SwapOut";
 const char* const kBuiltinSwapInTarget = "__builtin$SwapIn";
 const char* const kBuiltinSwapDoneTarget = "__builtin$SwapDone";
 const char* const kBuiltinMemZeroTarget = "__builtin$MemZero";
-const char* const kBuiltinCrossMeshAllReduceTarget = "__builtin$CrossMeshAllReduce"
+const char* const kBuiltinCrossMeshAllReduceTarget =
+    "__builtin$CrossMeshAllReduce";
 
 static ReductionDimensions GetReductionKindAndContiguousComponentsImpl(
     const Shape& input_shape, absl::Span<const int64_t> dims_to_reduce) {

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -153,6 +153,7 @@ const char* const kBuiltinSwapOutTarget = "__builtin$SwapOut";
 const char* const kBuiltinSwapInTarget = "__builtin$SwapIn";
 const char* const kBuiltinSwapDoneTarget = "__builtin$SwapDone";
 const char* const kBuiltinMemZeroTarget = "__builtin$MemZero";
+const char* const kBuiltinCrossMeshAllReduceTarget = "__builtin$CrossMeshAllReduce"
 
 static ReductionDimensions GetReductionKindAndContiguousComponentsImpl(
     const Shape& input_shape, absl::Span<const int64_t> dims_to_reduce) {

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -68,6 +68,7 @@ extern const char* const kBuiltinSwapOutTarget;
 extern const char* const kBuiltinSwapInTarget;
 extern const char* const kBuiltinSwapDoneTarget;
 extern const char* const kBuiltinMemZeroTarget;
+extern const char* const kBuiltinCrossMeshAllReduceTarget;
 
 // Returns true if either the dimensions being reduced or the dimensions being
 // kept are contiguous in the input of the reduce instruction.

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -181,6 +181,7 @@ class IrEmitterUnnested : public IrEmitter {
   Status EmitSwapThunk(mlir::Operation* op);
   Status EmitSwapDoneThunk(mlir::Operation* op);
   Status EmitMemZeroThunk(mlir::Operation* op);
+  Status EmitCrossMeshAllReduceTarget(mlir::Operation* op);
   Status EmitCustomCallThunk(mlir::Operation* op);
   Status EmitFftThunk(mlir::Operation* op);
   Status EmitFusion(mlir::Operation* op);

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -182,6 +182,9 @@ class IrEmitterUnnested : public IrEmitter {
   Status EmitSwapDoneThunk(mlir::Operation* op);
   Status EmitMemZeroThunk(mlir::Operation* op);
   Status EmitCrossMeshAllReduceTarget(mlir::Operation* op);
+  using Slices = std::vector<BufferAllocation::Slice>;
+  StatusOr<std::pair<Slices, Slices>> CustomCallParseBuffers(
+      mlir::Operation* op);
   Status EmitCustomCallThunk(mlir::Operation* op);
   Status EmitFftThunk(mlir::Operation* op);
   Status EmitFusion(mlir::Operation* op);

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
@@ -504,7 +504,7 @@ Status CrossMeshNcclAllReduceThunk::ExecuteOnStream(
   //     AcquireNcclComm(params.run_id, op_id, std::move(participants),
   //                     num_local_participants, *unique_id_callback, rank));
   // TODO(yonghao): support CrossMeshNcclAllReduce for different mesh groups as above
-  // using participants created at compile time
+  // using participants info created at compile time
   int device_ordinal = params.stream->parent()->device_ordinal();
   NcclComm::Lock comm = nccl_comms[device_ordinal]->Acquire();
 

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
@@ -461,11 +461,11 @@ Status NcclReduceScatterThunk::RunNcclCollective(const ExecuteParams& params,
 std::vector<std::unique_ptr<NcclComm>> nccl_comms;
 
 // FIXME(yonghao): support multiple groups of cross mesh nccl comms with keys
-void SetCrossMeshCommunicators(const std::vector<void*>& comms,
+void SetCrossMeshCommunicators(const std::vector<std::uintptr_t>& comms,
                                const std::string& group_keys) {
   nccl_comms.clear();
   nccl_comms.reserve(comms.size());
-  for (void* comm : comms) {
+  for (std::uintptr_t comm : comms) {
     nccl_comms.emplace_back(
         std::make_unique<NcclComm>(reinterpret_cast<ncclComm_t>(comm)));
   }

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
@@ -130,6 +130,26 @@ class NcclReduceScatterThunk : public NcclAllReduceThunkBase {
                            ncclComm_t comm) override;
 };
 
+class CrossMeshNcclAllReduceThunk : public Thunk {
+ public:
+  using Buffer = NcclCollectiveThunk::Buffer;
+
+  explicit CrossMeshNcclAllReduceThunk(ThunkInfo thunk_info,
+                                       std::vector<Buffer> buffers,
+                                       ReductionKind reduction_kind,
+                                       xla::PrimitiveType op_type);
+
+  Status ExecuteOnStream(const ExecuteParams& params) override;
+
+ private:
+  const NcclAllReduceConfig config_;
+  const std::vector<Buffer> buffers_;
+  bool first_call_to_execute_ = true;
+};
+
+void SetCrossMeshCommunicators(const std::vector<void*>& comms,
+                               const std::string& group_keys);
+
 }  // namespace gpu
 }  // namespace xla
 

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
@@ -147,7 +147,7 @@ class CrossMeshNcclAllReduceThunk : public Thunk {
   bool first_call_to_execute_ = true;
 };
 
-void SetCrossMeshCommunicators(const std::vector<void*>& comms,
+void SetCrossMeshCommunicators(const std::vector<std::uintptr_t>& comms,
                                const std::string& group_keys);
 
 }  // namespace gpu

--- a/tensorflow/compiler/xla/service/gpu/nccl_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_utils.h
@@ -108,6 +108,7 @@ TF_LIB_GTL_DEFINE_INT_TYPE(OpId, int64_t);
 
 struct NcclComm : public Lockable<ncclComm_t> {
   NcclComm() : Lockable(nullptr) {}
+  NcclComm(ncclComm_t comm) : Lockable(comm) {}
 };
 
 StatusOr<NcclComm::Lock> AcquireNcclComm(

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
@@ -1415,7 +1415,11 @@ BuildStrategyAndCost(const HloInstructionSequence& sequence,
         break;
       }
       case HloOpcode::kCustomCall: {
-        if (IsCustomCallMarker(ins)) {
+        if (ins->IsCustomCall(kCrossMeshAllReduce)) {
+          strategies = CreateLeafStrategyVector(instruction_id, ins, strategy_map,
+                                                leaf_strategies);
+          AddReplicatedStrategy(ins, cluster_env, strategy_map, strategies, 0);
+        } else if (IsCustomCallMarker(ins)) {
           const HloInstruction* operand = ins->operand(0);
           const StrategyVector* src_strategies = strategy_map.at(operand).get();
           CHECK(src_strategies->is_tuple);

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_util.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_util.cc
@@ -21,6 +21,7 @@ NullStream& NullStream::Global() {
 
 const char* const kPipelineMarker = "pipeline_marker";
 const char* const kIdentityMarker = "identity";
+const char* const kCrossMeshAllReduce = "__builtin$CrossMeshAllReduce";
 
 // Return whether a reshape instruction is a special reshape that switches
 // the batch dim of a dot.

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_util.h
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_util.h
@@ -29,6 +29,7 @@ using ReshardingCache =
 
 extern const char* const kPipelineMarker;
 extern const char* const kIdentityMarker;
+extern const char* const kCrossMeshAllReduce;
 constexpr absl::string_view kPipelineMarkerStartType = "start";
 constexpr absl::string_view kPipelineMarkerEndType = "end";
 
@@ -244,7 +245,8 @@ inline void ReplaceOperand(HloInstruction* inst,
 // Return whether this instruction is a custom call marker introduced by us.
 inline bool IsCustomCallMarker(const HloInstruction* inst) {
   return inst->IsCustomCall(kPipelineMarker) ||
-         inst->IsCustomCall(kIdentityMarker);
+         inst->IsCustomCall(kIdentityMarker) ||
+         inst->IsCustomCall(kCrossMeshAllReduce);
 }
 
 // Return whether the reshape is a special reshape that switches the batch dim

--- a/tensorflow/compiler/xla/service/spmd/auto_sharding_util.h
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding_util.h
@@ -245,8 +245,7 @@ inline void ReplaceOperand(HloInstruction* inst,
 // Return whether this instruction is a custom call marker introduced by us.
 inline bool IsCustomCallMarker(const HloInstruction* inst) {
   return inst->IsCustomCall(kPipelineMarker) ||
-         inst->IsCustomCall(kIdentityMarker) ||
-         inst->IsCustomCall(kCrossMeshAllReduce);
+         inst->IsCustomCall(kIdentityMarker);
 }
 
 // Return whether the reshape is a special reshape that switches the batch dim

--- a/tensorflow/compiler/xla/service/spmd/spmd_partitioner.cc
+++ b/tensorflow/compiler/xla/service/spmd/spmd_partitioner.cc
@@ -1504,7 +1504,8 @@ std::vector<ReplicaGroup> SpmdPartitioningVisitor::CreateReplicaGroups(
 }
 
 Status SpmdPartitioningVisitor::DefaultAction(HloInstruction* hlo) {
-  if (hlo->IsCustomCall("identity") || hlo->IsCustomCall("pipeline_marker")) {
+  if (hlo->IsCustomCall("identity") || hlo->IsCustomCall("pipeline_marker") ||
+      hlo->IsCustomCall("__builtin$CrossMeshAllReduce")) {
     return HandleElementwise(hlo);
   }
 

--- a/tensorflow/compiler/xla/service/spmd/stateful_rng_spmd_partitioner.cc
+++ b/tensorflow/compiler/xla/service/spmd/stateful_rng_spmd_partitioner.cc
@@ -79,7 +79,10 @@ bool StatefulRngSpmdPartitioner::CanSideEffectingHaveReplicatedSharding(
   // Alpa-specific changes for profling
   if (hlo->opcode() == HloOpcode::kAllReduce &&
       Cast<HloAllReduceInstruction>(hlo)->use_global_device_ids()) return true;
-  if (hlo->IsCustomCall(kPipelineMarker) || hlo->IsCustomCall(kIdentityMarker)) return true;
+  if (hlo->IsCustomCall(kPipelineMarker) ||
+      hlo->IsCustomCall(kIdentityMarker) ||
+      hlo->IsCustomCall(kCrossMeshAllReduce))
+    return true;
   return spmd::SpmdPartitioner::CanSideEffectingHaveReplicatedSharding(hlo);
 }
 


### PR DESCRIPTION
This PR:
- Adds a CrossMeshNcclAllReduce thunk to support allreduce in collective communication.
  The opaque of `__builtin$CrossMeshAllReduce` is the reduction op's type but is intended to include the participant mesh group to support multiple cross mesh allreduce later.
- Expose API to set nccl communicator. In later PR, it should support generating keys for different mesh groups and using a thread-safe map.
- Expose API to create nccl communicator.
  Communicators created by CuPy wraps `ncclComm_t` by `cdef`, so we cannot get access to the `ncclComm_t`. Instead, we create the communicators using nccl in XLA.