### PR TITLE
Convert pipeline_marker and OptimizationBarrier to bitcast

### DIFF
--- a/tensorflow/compiler/xla/service/optimization_barrier_expander.cc
+++ b/tensorflow/compiler/xla/service/optimization_barrier_expander.cc
@@ -15,77 +15,33 @@ limitations under the License.
 
 #include "tensorflow/compiler/xla/service/optimization_barrier_expander.h"
 
-// Added by alpa
-#include "tensorflow/compiler/xla/service/hlo_instructions.h"
-#include "tensorflow/compiler/xla/service/hlo_casting_utils.h"
-
 namespace xla {
 
 StatusOr<bool> OptimizationBarrierExpander::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   std::vector<HloInstruction*> barriers;
+
+  // Added by Alpa
   for (HloComputation* computation :
        module->MakeNonfusionComputations(execution_threads)) {
     bool modified = false;
     for (HloInstruction* inst : computation->instructions()) {
-      if (inst->opcode() == HloOpcode::kOptimizationBarrier) {
+      if (inst->IsCustomCall("pipeline_marker") || inst->opcode() == HloOpcode::kOptimizationBarrier) {
         barriers.push_back(inst);
         modified = true;
       }
     }
-
-    if (modified && module->has_schedule()) {
-      const auto& sequences = module->schedule().sequences();
-      auto it = sequences.find(computation->unique_id());
-      if (it != sequences.end()) {
-        std::vector<HloInstruction*> sequence;
-        sequence.reserve(it->second.instructions().size());
-        absl::c_copy_if(it->second.instructions(), std::back_inserter(sequence),
-                        [](HloInstruction* inst) {
-                          return inst->opcode() !=
-                                 HloOpcode::kOptimizationBarrier;
-                        });
-        module->schedule().set_sequence(computation, sequence);
-      }
-    }
   }
 
-  //for (HloInstruction* inst : barriers) {
-  //  HloInstruction* arg = inst->mutable_operand(0);
-  //  TF_RETURN_IF_ERROR(arg->CopyAllControlDepsFrom(inst));
-
-  //  TF_RETURN_IF_ERROR(inst->ReplaceAllUsesWith(arg));
-  //  TF_RETURN_IF_ERROR(inst->DropAllControlDeps());
-
-  //  TF_RETURN_IF_ERROR(inst->parent()->RemoveInstruction(inst));
-  //}
-
-  // Added by Alpa.
-  // We use identity markers to group these variables in a tuple.
-  // This greatly reduces the memory usage compared to the above
-  // default behavior.
   for (HloInstruction* inst : barriers) {
     HloInstruction* identity = inst->parent()->AddInstruction(
-	    HloInstruction::CreateCustomCall(inst->shape(), {inst->mutable_operand(0)},
-									     "identity"));
+        HloInstruction::CreateUnary(inst->shape(), HloOpcode::kBitcast,
+                                    inst->mutable_operand(0)));
     inst->ReplaceAllUsesWith(identity);
     inst->parent()->RemoveInstruction(inst);
-
-     // Set the input and output as alias
-     std::vector<std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>
-         aliasing;
-
-     ShapeUtil::VisitorFunction visitor = [&](const Shape& shape,
-                                              const ShapeIndex& idx) {
-       aliasing.push_back(std::make_pair(idx, std::make_pair(0, idx)));
-     };
-     ShapeUtil::ForEachSubshape(identity->shape(), visitor);
-     HloCustomCallInstruction* call = Cast<HloCustomCallInstruction>(identity);
-     call->set_output_to_operand_aliasing(aliasing);
   }
 
   return !barriers.empty();
 }
-
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/sharding_propagation.cc
+++ b/tensorflow/compiler/xla/service/sharding_propagation.cc
@@ -155,7 +155,7 @@ bool IsPassthroughCustomOps(const HloInstruction* hlo) {
     return true;
   }
   // Added by Alpa
-  if (hlo->IsCustomCall("pipeline_marker") || hlo->IsCustomCall("identity")) {
+  if (hlo->IsCustomCall("pipeline_marker")) {
     return true;
   }
   if (hlo->operand_count() != 1 || !hlo->shape().IsArray() ||


### PR DESCRIPTION
We do not need CustomCall anymore, we can simply convert pipeline_marker to bitcast for code generation.
This fixes a bug with customcall.