### PR TITLE
[FIX] add sharding propagation after auto sharding

### DIFF
--- a/tensorflow/compiler/xla/service/spmd/alpa_compiler.cc
+++ b/tensorflow/compiler/xla/service/spmd/alpa_compiler.cc
@@ -148,6 +148,9 @@ Status RunAutoShardingPass(HloModule* hlo_module,
       spmd_simplify.AddPass<HloDCE>();
 
       spmd_pipeline.AddPass<AutoSharding>();
+      spmd_pipeline.AddPass<ShardingPropagation>(
+          /*is_spmd=*/true, /*propagate_metadata=*/false,
+          /*allow_spmd_sharding_propagation_to_output=*/true);
       spmd_pipeline.AddPass<SliceAutoShardedStages>();
     } else {
       spmd_pipeline.AddPass<CallInliner>();


### PR DESCRIPTION
The FollowParallel calls `run_auto_sharding` but disables auto sharding. Instead, it simply uses the sharding propagation pass at the end of auto sharding, so we need to add `ShardingPropagation` back to the `run_auto_sharding`.