### PR TITLE
[FIX] Fix unsupported Gather in auto-sharding and shape mismatch

### DIFF
--- a/tensorflow/compiler/xla/service/spmd/alpa_compiler.cc
+++ b/tensorflow/compiler/xla/service/spmd/alpa_compiler.cc
@@ -152,10 +152,10 @@ Status RunAutoShardingPass(HloModule* hlo_module,
 
       spmd_simplify.AddPass<SortSimplifier>();
       spmd_simplify.AddPass<TupleSimplifier>();
-      spmd_simplify.AddPass<ScatterSimplifier>();
+      // spmd_simplify.AddPass<ScatterSimplifier>();
       spmd_simplify.AddPass<ScatterExpander>(
           ScatterExpander::kEliminateSimpleScatters);
-      spmd_simplify.AddPass<GatherSimplifier>();
+      // spmd_simplify.AddPass<GatherSimplifier>();
       spmd_simplify.AddPass<GatherExpander>(
           GatherExpander::kEliminateSimpleGathers);
       spmd_simplify.AddPass<WhileLoopConstantSinking>();


### PR DESCRIPTION
- The `SimplifyScatter` and `SimplifyGather` cause a `Does not support this kind of Gather` error in some models, and we comment out the two optimizations.
- The shape may mismatch in `RewriteAccGrad` pass, and we add a reshape for it.