### PR TITLE
[FIX] fix setting cross mesh communicator

### DIFF
--- a/tensorflow/compiler/xla/python/xla.cc
+++ b/tensorflow/compiler/xla/python/xla.cc
@@ -82,7 +82,6 @@ limitations under the License.
 #ifdef XLA_PYTHON_ENABLE_GPU
 #include "tensorflow/compiler/xla/service/gpu/alpa_events.h"
 #include "tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h"
-#include "tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h"
 
 PYBIND11_MAKE_OPAQUE(std::vector<ncclComm_t>);
 #endif // XLA_PYTHON_ENABLE_GPU
@@ -765,8 +764,9 @@ PYBIND11_MODULE(xla_extension, m) {
   m.def("set_num_device_on_host", &gpu::SetNumDeviceOnHost);
   m.def("set_idx_to_uuid", &gpu::XlaSetIdxToUuid);
   m.def("computation_wait_events", &gpu::alpa::ComputationWaitEvents);
-  m.def("create_cross_mesh_communicator", &gpu::CreateCrossMeshCommunicator,
-        "create nccl communicators for cross mesh collective communication");
+  m.def("set_comm_group_info", &gpu::alpa::SetCommGroup,
+        "set the mapping from meshes to the corresponding communication group "
+        "and nccl uuid");
   m.def("reset_event_context", &gpu::alpa::ResetEventContext);
   m.def("get_buffer_device_id", &gpu::alpa::GetBufferDeviceId,
         "get the local device id for one pybuffer");

--- a/tensorflow/compiler/xla/python/xla.cc
+++ b/tensorflow/compiler/xla/python/xla.cc
@@ -764,7 +764,7 @@ PYBIND11_MODULE(xla_extension, m) {
   m.def("set_num_device_on_host", &gpu::SetNumDeviceOnHost);
   m.def("set_idx_to_uuid", &gpu::XlaSetIdxToUuid);
   m.def("computation_wait_events", &gpu::alpa::ComputationWaitEvents);
-  m.def("set_comm_group_info", &gpu::alpa::SetCommGroup,
+  m.def("set_comm_group_info", &gpu::alpa::SetPyCommGroup,
         "set the mapping from meshes to the corresponding communication group "
         "and nccl uuid");
   m.def("reset_event_context", &gpu::alpa::ResetEventContext);

--- a/tensorflow/compiler/xla/python/xla.cc
+++ b/tensorflow/compiler/xla/python/xla.cc
@@ -739,28 +739,28 @@ PYBIND11_MODULE(xla_extension, m) {
       py::arg("compile_options") = CompileOptions());
 
 #ifdef XLA_PYTHON_ENABLE_GPU
-  py::class_<gpu::alpa::CommGroup, std::shared_ptr<gpu::alpa::CommGroup>>
+  py::class_<gpu::alpa::PyCommGroup, std::shared_ptr<gpu::alpa::PyCommGroup>>
       alpa_comm_group(m, "CommGroup");
   alpa_comm_group
       .def(py::init([](std::shared_ptr<PyClient> backend) {
-        return std::make_shared<gpu::alpa::CommGroup>(backend);
+        return std::make_shared<gpu::alpa::PyCommGroup>(backend);
       }))
-      .def("record_events", &gpu::alpa::CommGroup::CommunicatorRecordEvents)
-      .def("wait_events", &gpu::alpa::CommGroup::CommunicatorWaitEvents)
-      .def("comm_wait_compute", &gpu::alpa::CommGroup::CommWaitCompute)
-      .def("compute_wait_comm", &gpu::alpa::CommGroup::ComputeWaitComm)
+      .def("record_events", &gpu::alpa::PyCommGroup::CommunicatorRecordEvents)
+      .def("wait_events", &gpu::alpa::PyCommGroup::CommunicatorWaitEvents)
+      .def("comm_wait_compute", &gpu::alpa::PyCommGroup::CommWaitCompute)
+      .def("compute_wait_comm", &gpu::alpa::PyCommGroup::ComputeWaitComm)
       .def("nccl_create_communicators",
-           &gpu::alpa::CommGroup::NcclCreateCommunicators,
+           &gpu::alpa::PyCommGroup::NcclCreateCommunicators,
            "create nccl communicators for cross-mesh communication")
-      .def("nccl_destroy_comms", &gpu::alpa::CommGroup::NcclDestroyComms,
+      .def("nccl_destroy_comms", &gpu::alpa::PyCommGroup::NcclDestroyComms,
            "destroy comms")
-      .def("nccl_local_all_gather", &gpu::alpa::CommGroup::NcclLocalAllGather,
+      .def("nccl_local_all_gather", &gpu::alpa::PyCommGroup::NcclLocalAllGather,
            "nccl local allgather")
       .def("nccl_broadcast_partial_gpus",
-           &gpu::alpa::CommGroup::NcclBroadcastPartialGPUs,
+           &gpu::alpa::PyCommGroup::NcclBroadcastPartialGPUs,
            "nccl broadcast with only a subset of gpus in the host are involved")
-      .def("nccl_recv", &gpu::alpa::CommGroup::NcclRecv, "nccl recv data")
-      .def("nccl_send", &gpu::alpa::CommGroup::NcclSend, "nccl send data");
+      .def("nccl_recv", &gpu::alpa::PyCommGroup::NcclRecv, "nccl recv data")
+      .def("nccl_send", &gpu::alpa::PyCommGroup::NcclSend, "nccl send data");
   m.def("set_num_device_on_host", &gpu::SetNumDeviceOnHost);
   m.def("set_idx_to_uuid", &gpu::XlaSetIdxToUuid);
   m.def("computation_wait_events", &gpu::alpa::ComputationWaitEvents);

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -468,6 +468,8 @@ tf_cuda_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
         "@llvm-project//mlir:IR",
+        # Added by Alpa
+        ":alpa_nccl_wrapper",
     ],
 )
 

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -469,7 +469,7 @@ tf_cuda_library(
         "@com_google_absl//absl/synchronization",
         "@llvm-project//mlir:IR",
         # Added by Alpa
-        ":alpa_nccl_wrapper",
+        ":alpa_nccl_group_base",
     ],
 )
 
@@ -2979,14 +2979,14 @@ tf_cc_test(
 
 # Added by Alpa
 alias(
-    name = "alpa_nccl_wrapper",
-    actual = if_nccl(":_alpa_nccl_wrapper", ":empty"),
+    name = "alpa_nccl_group_base",
+    actual = if_nccl(":_alpa_nccl_group_base", ":empty"),
 )
 
 tf_cuda_library(
-    name = "_alpa_nccl_wrapper",
-    srcs = if_gpu_is_configured(["alpa_nccl_wrapper.cc"]),
-    hdrs = if_gpu_is_configured(["alpa_nccl_wrapper.h"]),
+    name = "_alpa_nccl_group_base",
+    srcs = if_gpu_is_configured(["alpa_nccl_group_base.cc"]),
+    hdrs = if_gpu_is_configured(["alpa_nccl_group_base.h"]),
     # Override tf_cuda_library()'s internal default value of ["//buildenv/target:gce"].
     copts = [
         "-fexceptions",
@@ -2996,7 +2996,7 @@ tf_cuda_library(
     defines = if_gpu_is_configured(["XLA_ENABLE_XCCL"]),
     deps = [
         ":alpa_event_manager",
-        "//tensorflow/compiler/xla/python:py_client",
+        "//tensorflow/compiler/xla/pjrt:pjrt_stream_executor_client",
     ] + if_gpu_is_configured([
         ":gpu_executable_run_options",
         ":nccl_utils",
@@ -3020,6 +3020,21 @@ cc_library(
         "//tensorflow/compiler/xla:status_macros",
         "//tensorflow/stream_executor:event",
         "@com_google_absl//absl/container:flat_hash_map",
+    ],
+)
+
+cc_library(
+    name = "alpa_nccl_wrapper",
+    srcs = [
+        "alpa_nccl_wrapper.cc",
+    ],
+    hdrs = [
+        "alpa_nccl_wrapper.h",
+    ],
+    defines = if_gpu_is_configured(["XLA_ENABLE_XCCL"]),
+    deps = [
+        "alpa_nccl_group_base",
+        "//tensorflow/compiler/xla/python:py_client",
     ],
 )
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.cc
@@ -101,7 +101,7 @@ absl::flat_hash_map<std::string, CrossMeshCommInfo> cross_mesh_comms;
 CUstream default_stream = NULL;
 };  // namespace
 
-CommGroup::CommGroup(PjRtStreamExecutorClient *client) {
+CommGroup::CommGroup(PjRtStreamExecutorClient *client) : client_(client) {
   if (client != nullptr) {
     for (int device_id = 0; device_id < client->device_count(); ++device_id) {
       auto executor = client->device_state(device_id).executor();

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.cc
@@ -1,0 +1,331 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file implements nccl apis for alpa to use.
+#include "tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.h"
+
+#ifdef XLA_ENABLE_XCCL
+#include "tensorflow/compiler/xla/service/gpu/alpa_events.h"
+#include "tensorflow/compiler/xla/stream_executor/gpu/gpu_stream.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#endif
+
+namespace stream_executor {};
+namespace se = ::stream_executor;
+
+namespace xla {
+namespace gpu {
+
+namespace alpa {
+namespace {
+StatusOr<std::uintptr_t> ToUnsafePointer(PjRtBuffer *buf) {
+  return buf->client()->UnsafeBufferPointer(buf);
+}
+
+StatusOr<ncclDataType_t> ToNcclDataType(PrimitiveType element_type) {
+  // FIXME(yonghao): throw an error for other cases
+  switch (element_type) {
+    case S8:
+      return ncclInt8;
+    case PRED:
+    case U8:
+      return ncclUint8;
+    case S32:
+      return ncclInt32;
+    case U32:
+      return ncclUint32;
+    case S64:
+      return ncclInt64;
+    case U64:
+      return ncclUint64;
+    case F16:
+      return ncclFloat16;
+    case F32:
+    case C64:
+      return ncclFloat32;
+    case F64:
+    case C128:
+      return ncclFloat64;
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+    case BF16:
+      return ncclBfloat16;
+#endif
+    default:
+      return Unimplemented("Nccl does not support the type.");
+  }
+}
+
+int SizeOfType(ncclDataType_t element_type) {
+  switch (element_type) {
+    case ncclInt8:
+      return 1;
+    case ncclUint8:
+      return 1;
+    case ncclInt32:
+      return 4;
+    case ncclUint32:
+      return 4;
+    case ncclInt64:
+      return 8;
+    case ncclUint64:
+      return 8;
+    case ncclFloat16:
+      return 2;
+    case ncclFloat32:
+      return 4;
+    case ncclFloat64:
+      return 8;
+    default:
+      return 4;
+  }
+}
+
+CUstream GetCudaStream(se::Stream *stream) {
+  return reinterpret_cast<CUstream>(se::gpu::AsGpuStreamValue(stream));
+}
+
+using CrossMeshCommInfo = std::pair<CommGroup *, AlpaNcclUid>;
+absl::flat_hash_map<std::string, CrossMeshCommInfo> cross_mesh_comms;
+CUstream default_stream = NULL;
+};  // namespace
+
+CommGroup::CommGroup(PjRtStreamExecutorClient *client) {
+  if (client != nullptr) {
+    for (int device_id = 0; device_id < client->device_count(); ++device_id) {
+      auto executor = client->device_state(device_id).executor();
+      auto i_stream = std::make_unique<se::Stream>(executor);
+      auto o_stream = std::make_unique<se::Stream>(executor);
+      i_stream->Init();
+      o_stream->Init();
+      recv_streams.emplace_back(std::move(i_stream));
+      send_streams.emplace_back(std::move(o_stream));
+      executors.push_back(executor);
+    }
+  }
+}
+
+// Communicator related functions:
+Status CommGroup::NcclCreateCommunicators(
+    int world_size, const std::vector<int> &device_global_ranks,
+    const std::vector<int> &device_ids, const AlpaNcclUid &nccl_uid_vec) {
+#if XLA_ENABLE_XCCL
+  int n_devices = device_global_ranks.size();
+  CHECK_EQ(n_devices, device_ids.size());
+  ncclUniqueId nccl_uid = NcclUidDeserialize(nccl_uid_vec);
+  // Create Communicators
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
+  for (int i = 0; i < n_devices; i++) {
+    cudaSetDevice(device_ids[i]);
+    int rank = device_global_ranks[i];
+    auto comm_key = std::make_pair(nccl_uid_vec, device_ids[i]);
+    NcclComm::Lock comm = comm_map[comm_key].Acquire();
+    XLA_CUDA_RETURN_IF_ERROR(
+        ncclCommInitRank(comm.get(), world_size, nccl_uid, rank));
+  }
+  local_ids[nccl_uid_vec] = device_ids;
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
+  return OkStatus();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
+
+Status CommGroup::NcclDestroyComms(const AlpaNcclUid &nccl_uid_vec) {
+#if XLA_ENABLE_XCCL
+  for (int device_id : local_ids[nccl_uid_vec]) {
+    auto key = std::make_pair(nccl_uid_vec, device_id);
+    XLA_CUDA_RETURN_IF_ERROR(ncclCommDestroy(*comm_map[key].Acquire()));
+  }
+  return OkStatus();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
+
+// Communication operation related functions:
+// FIXME: local allgather is deprecated
+Status CommGroup::NcclLocalAllGatherImpl(
+    const AlpaNcclUid &key, std::vector<PjRtBuffer *> buffers,
+    std::vector<uint> local_start_positions, uint global_start, uint n_elements,
+    bool use_default_stream) {
+#if XLA_ENABLE_XCCL
+  const auto &device_ids = local_ids[key];
+  int n_devices = device_ids.size();
+  CHECK_EQ(n_devices, buffers.size());
+  CHECK_EQ(n_devices, local_start_positions.size());
+
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t dtype,
+      ToNcclDataType(buffers[0]->on_device_shape().element_type()));
+  int dtype_size = SizeOfType(dtype);
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
+  for (int i = 0; i < n_devices; ++i) {
+    // FIXME(yonghao): use assign or return
+    TF_ASSIGN_OR_RETURN(std::uintptr_t sendbuff, ToUnsafePointer(buffers[i]));
+    sendbuff = sendbuff + local_start_positions[i] * dtype_size;
+    TF_ASSIGN_OR_RETURN(std::uintptr_t recvbuff, ToUnsafePointer(buffers[i]));
+    recvbuff = recvbuff + global_start * dtype_size;
+    auto comm = *comm_map[std::make_pair(key, device_ids[i])].Acquire();
+    auto stream = (use_default_stream ? default_stream
+                                      : GetCudaStream(recv_streams[i].get()));
+    XLA_CUDA_RETURN_IF_ERROR(ncclAllGather((void *)sendbuff, (void *)recvbuff,
+                                           n_elements, dtype, comm, stream));
+  }
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
+  return OkStatus();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
+
+Status CommGroup::NcclBroadcastPartialGPUsImpl(
+    const AlpaNcclUid &key, std::vector<PjRtBuffer *> buffers,
+    std::vector<uint> local_start_positions, uint n_elements, int root_rank,
+    bool use_recv_stream, bool use_default_stream) {
+#if XLA_ENABLE_XCCL
+  const auto &device_ids = local_ids[key];
+  int n_devices = device_ids.size();
+  CHECK_EQ(n_devices, buffers.size());
+  CHECK_EQ(n_devices, local_start_positions.size());
+
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t dtype,
+      ToNcclDataType(buffers[0]->on_device_shape().element_type()));
+  int dtype_size = SizeOfType(dtype);
+
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
+  for (int i = 0; i < n_devices; ++i) {
+    int device_id = device_ids[i];
+    TF_ASSIGN_OR_RETURN(std::uintptr_t sendbuff, ToUnsafePointer(buffers[i]));
+    sendbuff = sendbuff + local_start_positions[i] * dtype_size;
+    TF_ASSIGN_OR_RETURN(std::uintptr_t recvbuff, ToUnsafePointer(buffers[i]));
+    recvbuff = recvbuff + local_start_positions[i] * dtype_size;
+
+    auto comm = *comm_map[std::make_pair(key, device_id)].Acquire();
+    auto se_stream = use_default_stream
+                         ? nullptr
+                         : use_recv_stream ? recv_streams[device_id].get()
+                                           : send_streams[device_id].get();
+    auto stream =
+        use_default_stream ? default_stream : GetCudaStream(se_stream);
+    XLA_CUDA_RETURN_IF_ERROR(ncclBroadcast((void *)sendbuff, (void *)recvbuff,
+                                           n_elements, dtype, root_rank, comm,
+                                           stream));
+  }
+  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
+  return OkStatus();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
+
+Status CommGroup::NcclSendImpl(const AlpaNcclUid &key, PjRtBuffer *buffer,
+                               uint start, uint n_elements, int peer_p2p_rank,
+                               bool use_default_stream) {
+#if XLA_ENABLE_XCCL
+  const int device_id = local_ids[key][0];
+  TF_ASSIGN_OR_RETURN(ncclDataType_t dtype,
+                      ToNcclDataType(buffer->on_device_shape().element_type()));
+  int dtype_size = SizeOfType(dtype);
+  TF_ASSIGN_OR_RETURN(std::uintptr_t sendbuff, ToUnsafePointer(buffer));
+  sendbuff = sendbuff + start * dtype_size;
+  auto comm = *comm_map[std::make_pair(key, device_id)].Acquire();
+  auto stream = use_default_stream
+                    ? default_stream
+                    : GetCudaStream(send_streams[device_id].get());
+  XLA_CUDA_RETURN_IF_ERROR(ncclSend((void *)sendbuff, n_elements, dtype,
+                                    peer_p2p_rank, comm, stream));
+  // cudaDeviceSynchronize();
+  return OkStatus();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
+
+Status CommGroup::NcclRecvImpl(const AlpaNcclUid &key, PjRtBuffer *buffer,
+                               uint start, uint n_elements, int peer_p2p_rank,
+                               bool use_default_stream) {
+#if XLA_ENABLE_XCCL
+  const int device_id = local_ids[key][0];
+  TF_ASSIGN_OR_RETURN(ncclDataType_t dtype,
+                      ToNcclDataType(buffer->on_device_shape().element_type()));
+  int dtype_size = SizeOfType(dtype);
+  TF_ASSIGN_OR_RETURN(std::uintptr_t recvbuff, ToUnsafePointer(buffer));
+  recvbuff = recvbuff + start * dtype_size;
+  auto comm = *comm_map[std::make_pair(key, device_id)].Acquire();
+  auto stream = use_default_stream
+                    ? default_stream
+                    : GetCudaStream(recv_streams[device_id].get());
+  XLA_CUDA_RETURN_IF_ERROR(ncclRecv((void *)recvbuff, n_elements, dtype,
+                                    peer_p2p_rank, comm, stream));
+  // cudaDeviceSynchronize();
+  return OkStatus();
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
+
+// Other function
+NcclComm::Lock CommGroup::AcquireComm(const AlpaNcclUid &key, int device_id) {
+  return comm_map[std::make_pair(key, device_id)].Acquire();
+}
+
+// Cross-mesh allreduce thunk related
+void SetCommGroup(std::string key, CommGroup *g, const AlpaNcclUid uid) {
+  cross_mesh_comms.emplace(key, std::make_pair(g, uid));
+}
+
+NcclComm::Lock GetCommunicator(std::string key, size_t device_id) {
+  CrossMeshCommInfo &info = cross_mesh_comms.at(key);
+  return info.first->AcquireComm(info.second, device_id);
+}
+
+// Other functions
+AlpaNcclUid NcclUidSerialize(ncclUniqueId nccl_uid) {
+  AlpaNcclUid nccl_uid_vec(sizeof(nccl_uid.internal), 0);
+  memcpy(nccl_uid_vec.data(), &nccl_uid.internal, sizeof(nccl_uid.internal));
+  return nccl_uid_vec;
+}
+
+ncclUniqueId NcclUidDeserialize(const AlpaNcclUid &nccl_uid_vec) {
+  ncclUniqueId nccl_uid;
+  CHECK_EQ(sizeof(nccl_uid.internal), nccl_uid_vec.size());
+  memcpy(&nccl_uid.internal, nccl_uid_vec.data(), sizeof(nccl_uid.internal));
+  return nccl_uid;
+}
+
+StatusOr<AlpaNcclUid> NcclGetUniqueId() {
+#if XLA_ENABLE_XCCL
+  ncclUniqueId id;
+  XLA_CUDA_RETURN_IF_ERROR(ncclGetUniqueId(&id));
+  AlpaNcclUid nccl_uid_vec = NcclUidSerialize(id);
+  return nccl_uid_vec;
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
+
+StatusOr<int> NcclGetVersion() {
+#if XLA_ENABLE_XCCL
+  int version;
+  XLA_CUDA_RETURN_IF_ERROR(ncclGetVersion(&version));
+  return version;
+#else   // XLA_ENABLE_XCCL
+  return Unimplemented("NCCL support is not available.");
+#endif  // XLA_ENABLE_XCCL
+}
+}  // namespace alpa
+}  // namespace gpu
+}  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.cc
@@ -86,6 +86,10 @@ int SizeOfType(ncclDataType_t element_type) {
       return 4;
     case ncclFloat64:
       return 8;
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+    case ncclBfloat16:
+      return 2;
+#endif
     default:
       return 4;
   }

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.cc
@@ -27,7 +27,6 @@ namespace se = ::stream_executor;
 
 namespace xla {
 namespace gpu {
-
 namespace alpa {
 namespace {
 StatusOr<std::uintptr_t> ToUnsafePointer(PjRtBuffer *buf) {
@@ -96,7 +95,7 @@ CUstream GetCudaStream(se::Stream *stream) {
   return reinterpret_cast<CUstream>(se::gpu::AsGpuStreamValue(stream));
 }
 
-using CrossMeshCommInfo = std::pair<CommGroup *, AlpaNcclUid>;
+using CrossMeshCommInfo = std::pair<std::shared_ptr<CommGroup>, AlpaNcclUid>;
 absl::flat_hash_map<std::string, CrossMeshCommInfo> cross_mesh_comms;
 CUstream default_stream = NULL;
 };  // namespace
@@ -283,7 +282,8 @@ NcclComm::Lock CommGroup::AcquireComm(const AlpaNcclUid &key, int device_id) {
 }
 
 // Cross-mesh allreduce thunk related
-void SetCommGroup(std::string key, CommGroup *g, const AlpaNcclUid uid) {
+void SetCommGroup(std::string key, std::shared_ptr<CommGroup> g,
+                  const AlpaNcclUid &uid) {
   cross_mesh_comms.emplace(key, std::make_pair(g, uid));
 }
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.h
@@ -75,12 +75,14 @@ class CommGroup {
   absl::flat_hash_map<AlpaNcclUid, std::vector<int>> local_ids;
   std::vector<se::StreamExecutor *> executors;
   PjRtStreamExecutorClient *client_;
+
  private:
   ThreadSafeMap<std::pair<AlpaNcclUid, int>, NcclComm> comm_map;
 };
 
 // Cross-mesh allreduce thunk related
-void SetCommGroup(std::string key, CommGroup *g, const AlpaNcclUid uid);
+void SetCommGroup(std::string key, std::shared_ptr<CommGroup> g,
+                  const AlpaNcclUid &uid);
 
 NcclComm::Lock GetCommunicator(std::string key, size_t device_id);
 

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.h
@@ -74,7 +74,7 @@ class CommGroup {
   std::vector<std::unique_ptr<se::Stream>> send_streams, recv_streams;
   absl::flat_hash_map<AlpaNcclUid, std::vector<int>> local_ids;
   std::vector<se::StreamExecutor *> executors;
-  PjRtStreamExecutorClient *client;
+  PjRtStreamExecutorClient *client_;
  private:
   ThreadSafeMap<std::pair<AlpaNcclUid, int>, NcclComm> comm_map;
 };

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.h
@@ -1,0 +1,96 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file contains nccl api for alpa to use.
+
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_ALPA_NCCL_GROUP_BASE_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_ALPA_NCCL_GROUP_BASE_H_
+// Common place for all collective thunks to include nccl/rccl headers.
+#if TENSORFLOW_USE_ROCM
+#include "rocm/include/rccl/rccl.h"
+#else
+#include "third_party/nccl/nccl.h"
+#endif
+
+#include "tensorflow/compiler/xla/pjrt/pjrt_stream_executor_client.h"
+#include "tensorflow/compiler/xla/service/gpu/nccl_utils.h"
+#include "tensorflow/compiler/xla/service/rendezvous.h"
+
+namespace xla {
+namespace gpu {
+namespace alpa {
+using AlpaNcclUid = std::vector<int8_t>;
+using AlpaUuids = std::vector<int>;
+
+class CommGroup {
+ public:
+  CommGroup(PjRtStreamExecutorClient *client);
+  // Communicator related functions:
+  Status NcclCreateCommunicators(int world_size,
+                                 const std::vector<int> &device_global_ranks,
+                                 const std::vector<int> &device_ids,
+                                 const AlpaNcclUid &nccl_uid_vec);
+
+  Status NcclDestroyComms(const AlpaNcclUid &storage);
+
+  // Communication operations:
+  Status NcclLocalAllGatherImpl(const AlpaNcclUid &key,
+                                std::vector<PjRtBuffer *> buffers,
+                                std::vector<uint> local_start_positions,
+                                uint global_start, uint n_elements,
+                                bool use_default_stream);
+
+  Status NcclBroadcastPartialGPUsImpl(const AlpaNcclUid &key,
+                                      std::vector<PjRtBuffer *> buffers,
+                                      std::vector<uint> local_start_positions,
+                                      uint n_elements, int root_rank,
+                                      bool use_recv_stream,
+                                      bool use_default_stream);
+
+  Status NcclSendImpl(const AlpaNcclUid &key, PjRtBuffer *buffer, uint start,
+                      uint n_elements, int peer_p2p_rank,
+                      bool use_default_stream);
+
+  Status NcclRecvImpl(const AlpaNcclUid &key, PjRtBuffer *buffer, uint start,
+                      uint n_elements, int peer_p2p_rank,
+                      bool use_default_stream);
+
+  // Other functions
+  NcclComm::Lock AcquireComm(const AlpaNcclUid &uuids, int device_id);
+
+ protected:
+  std::vector<std::unique_ptr<se::Stream>> send_streams, recv_streams;
+  absl::flat_hash_map<AlpaNcclUid, std::vector<int>> local_ids;
+  std::vector<se::StreamExecutor *> executors;
+  PjRtStreamExecutorClient *client;
+ private:
+  ThreadSafeMap<std::pair<AlpaNcclUid, int>, NcclComm> comm_map;
+};
+
+// Cross-mesh allreduce thunk related
+void SetCommGroup(std::string key, CommGroup *g, const AlpaNcclUid uid);
+
+NcclComm::Lock GetCommunicator(std::string key, size_t device_id);
+
+// Other functions
+ncclUniqueId NcclUidDeserialize(const AlpaNcclUid &nccl_uid_chars);
+
+StatusOr<AlpaNcclUid> NcclGetUniqueId();
+
+StatusOr<int> NcclGetVersion();
+}  // namespace alpa
+}  // namespace gpu
+}  // namespace xla
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_ALPA_NCCL_GROUP_BASE_H_

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -41,269 +41,89 @@ void AddCallBackReleasingBuffer(se::Stream *stream, PyBuffer::object &buf_obj) {
   stream->ThenDoHostCallback([pjrt_ref]() {});
 }
 
-StatusOr<ncclDataType_t> ToNcclDataType(PrimitiveType element_type) {
-  // FIXME(yonghao): throw an error for other cases
-  switch (element_type) {
-    case S8:
-      return ncclInt8;
-    case PRED:
-    case U8:
-      return ncclUint8;
-    case S32:
-      return ncclInt32;
-    case U32:
-      return ncclUint32;
-    case S64:
-      return ncclInt64;
-    case U64:
-      return ncclUint64;
-    case F16:
-      return ncclFloat16;
-    case F32:
-    case C64:
-      return ncclFloat32;
-    case F64:
-    case C128:
-      return ncclFloat64;
-#if defined(__CUDA_BF16_TYPES_EXIST__)
-    case BF16:
-      return ncclBfloat16;
-#endif
-    default:
-      return Unimplemented("Nccl does not support the type.");
-  }
-}
-
-int SizeOfType(ncclDataType_t element_type) {
-  switch (element_type) {
-    case ncclInt8:
-      return 1;
-    case ncclUint8:
-      return 1;
-    case ncclInt32:
-      return 4;
-    case ncclUint32:
-      return 4;
-    case ncclInt64:
-      return 8;
-    case ncclUint64:
-      return 8;
-    case ncclFloat16:
-      return 2;
-    case ncclFloat32:
-      return 4;
-    case ncclFloat64:
-      return 8;
-    default:
-      return 4;
-  }
-}
-
-CUstream GetCudaStream(se::Stream *stream) {
-  return reinterpret_cast<CUstream>(se::gpu::AsGpuStreamValue(stream));
-}
-
 se::Stream *GetXlaStream(PjRtStreamExecutorClient *client, bool is_compute,
                          int device_id) {
   return is_compute ? client->device_state(device_id).compute_stream()
                     : client->device_state(0).GetLastDeviceToDeviceStream();
 }
-
-using CrossMeshCommInfo = std::pair<CommGroup *, AlpaNcclUid>;
-absl::flat_hash_map<std::string, CrossMeshCommInfo> cross_mesh_comms;
-CUstream default_stream = NULL;
 };  // namespace
 
-CommGroup::CommGroup(std::shared_ptr<PyClient> backend) {
-  if (backend != nullptr) {
-    client = tensorflow::down_cast<PjRtStreamExecutorClient *>(
-        backend->pjrt_client());
-    for (int device_id = 0; device_id < client->device_count(); ++device_id) {
-      auto executor = client->device_state(device_id).executor();
-      auto i_stream = std::make_unique<se::Stream>(executor);
-      auto o_stream = std::make_unique<se::Stream>(executor);
-      i_stream->Init();
-      o_stream->Init();
-      recv_streams.emplace_back(std::move(i_stream));
-      send_streams.emplace_back(std::move(o_stream));
-      executors.push_back(executor);
-    }
-  }
-}
-
-// Communicator related functions:
-Status CommGroup::NcclCreateCommunicators(
-    int world_size, const std::vector<int> &device_global_ranks,
-    const std::vector<int> &device_ids, const AlpaNcclUid &nccl_uid_vec) {
-#if XLA_ENABLE_XCCL
-  int n_devices = device_global_ranks.size();
-  CHECK_EQ(n_devices, device_ids.size());
-  ncclUniqueId nccl_uid = NcclUidDeserialize(nccl_uid_vec);
-  // Create Communicators
-  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
-  for (int i = 0; i < n_devices; i++) {
-    cudaSetDevice(device_ids[i]);
-    int rank = device_global_ranks[i];
-    auto comm_key = std::make_pair(nccl_uid_vec, device_ids[i]);
-    NcclComm::Lock comm = comm_map[comm_key].Acquire();
-    XLA_CUDA_RETURN_IF_ERROR(
-        ncclCommInitRank(comm.get(), world_size, nccl_uid, rank));
-  }
-  local_ids[nccl_uid_vec] = device_ids;
-  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
-  return OkStatus();
-#else   // XLA_ENABLE_XCCL
-  return Unimplemented("NCCL support is not available.");
-#endif  // XLA_ENABLE_XCCL
-}
-
-Status CommGroup::NcclDestroyComms(const AlpaNcclUid &nccl_uid_vec) {
-#if XLA_ENABLE_XCCL
-  for (int device_id : local_ids[nccl_uid_vec]) {
-    auto key = std::make_pair(nccl_uid_vec, device_id);
-    XLA_CUDA_RETURN_IF_ERROR(ncclCommDestroy(*comm_map[key].Acquire()));
-  }
-  return OkStatus();
-#else   // XLA_ENABLE_XCCL
-  return Unimplemented("NCCL support is not available.");
-#endif  // XLA_ENABLE_XCCL
-}
+PyCommGroup::PyCommGroup(std::shared_ptr<PyClient> backend)
+    : CommGroup(backend == nullptr
+                    ? nullptr
+                    : tensorflow::down_cast<PjRtStreamExecutorClient *>(
+                          backend->pjrt_client())) {}
 
 // Communication operation related functions:
 // FIXME: local allgather is deprecated
-Status CommGroup::NcclLocalAllGather(const AlpaNcclUid &key,
+Status PyCommGroup::NcclLocalAllGather(const AlpaNcclUid &key,
                                      std::vector<PyBuffer::object> buffers,
                                      std::vector<uint> local_start_positions,
                                      uint global_start, uint n_elements,
                                      bool use_default_stream) {
-#if XLA_ENABLE_XCCL
-  const auto &device_ids = local_ids[key];
-  int n_devices = device_ids.size();
-  CHECK_EQ(n_devices, buffers.size());
-  CHECK_EQ(n_devices, local_start_positions.size());
-
-  TF_ASSIGN_OR_RETURN(
-      ncclDataType_t dtype,
-      ToNcclDataType(
-          buffers[0].buf()->buffer()->on_device_shape().element_type()));
-  int dtype_size = SizeOfType(dtype);
-  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
-  for (int i = 0; i < n_devices; ++i) {
-    // FIXME(yonghao): use assign or return
-    TF_ASSIGN_OR_RETURN(std::uintptr_t sendbuff,
-                        buffers[i].buf()->UnsafeBufferPointer());
-    sendbuff = sendbuff + local_start_positions[i] * dtype_size;
-    TF_ASSIGN_OR_RETURN(std::uintptr_t recvbuff,
-                        buffers[i].buf()->UnsafeBufferPointer());
-    recvbuff = recvbuff + global_start * dtype_size;
-    auto comm = *comm_map[std::make_pair(key, device_ids[i])].Acquire();
-    auto stream = (use_default_stream ? default_stream
-                                      : GetCudaStream(recv_streams[i].get()));
-    XLA_CUDA_RETURN_IF_ERROR(ncclAllGather((void *)sendbuff, (void *)recvbuff,
-                                           n_elements, dtype, comm, stream));
+  std::vector<PjRtBuffer *> pjrt_buffers;
+  for (auto& buf : buffers) {
+    pjrt_buffers.push_back(buf.buf()->buffer());
   }
-  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
-  return OkStatus();
-#else   // XLA_ENABLE_XCCL
-  return Unimplemented("NCCL support is not available.");
-#endif  // XLA_ENABLE_XCCL
+  return NcclLocalAllGatherImpl(key, pjrt_buffers, local_start_positions,
+                                global_start, n_elements, use_default_stream);
 }
 
-Status CommGroup::NcclBroadcastPartialGPUs(
+Status PyCommGroup::NcclBroadcastPartialGPUs(
     const AlpaNcclUid &key, std::vector<PyBuffer::object> buffers,
     std::vector<uint> local_start_positions, uint n_elements, int root_rank,
     bool use_recv_stream, bool use_default_stream) {
+  std::vector<PjRtBuffer *> pjrt_buffers;
+  for (auto& buf : buffers) {
+    pjrt_buffers.push_back(buf.buf()->buffer());
+  }
+  TF_RETURN_IF_ERROR(NcclBroadcastPartialGPUsImpl(
+      key, pjrt_buffers, local_start_positions, n_elements, root_rank,
+      use_recv_stream, use_default_stream));
 #if XLA_ENABLE_XCCL
   const auto &device_ids = local_ids[key];
   int n_devices = device_ids.size();
-  CHECK_EQ(n_devices, buffers.size());
-  CHECK_EQ(n_devices, local_start_positions.size());
-
-  TF_ASSIGN_OR_RETURN(
-      ncclDataType_t dtype,
-      ToNcclDataType(
-          buffers[0].buf()->buffer()->on_device_shape().element_type()));
-  int dtype_size = SizeOfType(dtype);
-
-  XLA_CUDA_RETURN_IF_ERROR(ncclGroupStart());
   for (int i = 0; i < n_devices; ++i) {
     int device_id = device_ids[i];
-    TF_ASSIGN_OR_RETURN(std::uintptr_t sendbuff,
-                        buffers[i].buf()->UnsafeBufferPointer());
-    sendbuff = sendbuff + local_start_positions[i] * dtype_size;
-    TF_ASSIGN_OR_RETURN(std::uintptr_t recvbuff,
-                        buffers[i].buf()->UnsafeBufferPointer());
-    recvbuff = recvbuff + local_start_positions[i] * dtype_size;
-
-    auto comm = *comm_map[std::make_pair(key, device_id)].Acquire();
     auto se_stream = use_default_stream
                          ? nullptr
                          : use_recv_stream ? recv_streams[device_id].get()
                                            : send_streams[device_id].get();
-    auto stream =
-        use_default_stream ? default_stream : GetCudaStream(se_stream);
-    XLA_CUDA_RETURN_IF_ERROR(ncclBroadcast((void *)sendbuff, (void *)recvbuff,
-                                           n_elements, dtype, root_rank, comm,
-                                           stream));
     if (!use_recv_stream && !use_default_stream) {
       AddCallBackReleasingBuffer(se_stream, buffers[i]);
     }
   }
-  XLA_CUDA_RETURN_IF_ERROR(ncclGroupEnd());
   return OkStatus();
 #else   // XLA_ENABLE_XCCL
   return Unimplemented("NCCL support is not available.");
 #endif  // XLA_ENABLE_XCCL
 }
 
-Status CommGroup::NcclSend(const AlpaNcclUid &key, PyBuffer::object buffer,
+Status PyCommGroup::NcclSend(const AlpaNcclUid &key, PyBuffer::object buffer,
                            uint start, uint n_elements, int peer_p2p_rank,
                            bool use_default_stream) {
 #if XLA_ENABLE_XCCL
   const int device_id = local_ids[key][0];
-  TF_ASSIGN_OR_RETURN(
-      ncclDataType_t dtype,
-      ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type()));
-  int dtype_size = SizeOfType(dtype);
-  TF_ASSIGN_OR_RETURN(std::uintptr_t sendbuff,
-                      buffer.buf()->UnsafeBufferPointer());
-  sendbuff = sendbuff + start * dtype_size;
-  auto comm = *comm_map[std::make_pair(key, device_id)].Acquire();
-  auto stream = use_default_stream
-                    ? default_stream
-                    : GetCudaStream(send_streams[device_id].get());
-  XLA_CUDA_RETURN_IF_ERROR(ncclSend((void *)sendbuff, n_elements, dtype,
-                                    peer_p2p_rank, comm, stream));
+  TF_RETURN_IF_ERROR(NcclSendImpl(key, buffer.buf()->buffer(), start,
+                                  n_elements, peer_p2p_rank,
+                                  use_default_stream));
   if (!use_default_stream) {
     AddCallBackReleasingBuffer(send_streams[device_id].get(), buffer);
   }
-  // cudaDeviceSynchronize();
   return OkStatus();
 #else   // XLA_ENABLE_XCCL
   return Unimplemented("NCCL support is not available.");
 #endif  // XLA_ENABLE_XCCL
 }
 
-Status CommGroup::NcclRecv(const AlpaNcclUid &key, PyBuffer::object buffer,
+Status PyCommGroup::NcclRecv(const AlpaNcclUid &key, PyBuffer::object buffer,
                            uint start, uint n_elements, int peer_p2p_rank,
                            bool use_default_stream) {
 #if XLA_ENABLE_XCCL
   const int device_id = local_ids[key][0];
-  TF_ASSIGN_OR_RETURN(
-      ncclDataType_t dtype,
-      ToNcclDataType(buffer.buf()->buffer()->on_device_shape().element_type()));
-  int dtype_size = SizeOfType(dtype);
-  TF_ASSIGN_OR_RETURN(std::uintptr_t recvbuff,
-                      buffer.buf()->UnsafeBufferPointer());
-  recvbuff = recvbuff + start * dtype_size;
-  auto comm = *comm_map[std::make_pair(key, device_id)].Acquire();
-  auto stream = use_default_stream
-                    ? default_stream
-                    : GetCudaStream(recv_streams[device_id].get());
-  XLA_CUDA_RETURN_IF_ERROR(ncclRecv((void *)recvbuff, n_elements, dtype,
-                                    peer_p2p_rank, comm, stream));
-  // TF_RETURN_IF_ERROR(AddCallBackReleasingBuffer(stream, buffer));
-  // cudaDeviceSynchronize();
+  TF_RETURN_IF_ERROR(NcclSendImpl(key, buffer.buf()->buffer(), start,
+                                  n_elements, peer_p2p_rank,
+                                  use_default_stream));
   return OkStatus();
 #else   // XLA_ENABLE_XCCL
   return Unimplemented("NCCL support is not available.");
@@ -311,7 +131,7 @@ Status CommGroup::NcclRecv(const AlpaNcclUid &key, PyBuffer::object buffer,
 }
 
 // Sync functions:
-Status CommGroup::CommunicatorRecordEvents(const AlpaUuids &uuids,
+Status PyCommGroup::CommunicatorRecordEvents(const AlpaUuids &uuids,
                                            int num_devices, bool is_send) {
   for (int uuid : uuids) {
     TF_RETURN_IF_ERROR(ResetEvents(uuid));
@@ -328,7 +148,7 @@ Status CommGroup::CommunicatorRecordEvents(const AlpaUuids &uuids,
   return OkStatus();
 }
 
-Status CommGroup::CommunicatorWaitEvents(const AlpaUuids &uuids,
+Status PyCommGroup::CommunicatorWaitEvents(const AlpaUuids &uuids,
                                          int num_devices, bool is_send) {
   auto &streams = is_send ? send_streams : recv_streams;
   for (int uuid : uuids) {
@@ -337,24 +157,20 @@ Status CommGroup::CommunicatorWaitEvents(const AlpaUuids &uuids,
   return OkStatus();
 }
 
-void CommGroup::CommWaitCompute(bool is_send, bool is_compute, int device_id) {
+void PyCommGroup::CommWaitCompute(bool is_send, bool is_compute, int device_id) {
   se::Stream *waited = GetXlaStream(client, is_compute, device_id);
   se::Stream *waiting =
       is_send ? send_streams[device_id].get() : recv_streams[device_id].get();
   waiting->ThenWaitFor(waited);
 }
 
-void CommGroup::ComputeWaitComm(bool is_send, bool is_compute, int device_id) {
+void PyCommGroup::ComputeWaitComm(bool is_send, bool is_compute, int device_id) {
   se::Stream *waiting = GetXlaStream(client, is_compute, device_id);
   se::Stream *waited =
       is_send ? send_streams[device_id].get() : recv_streams[device_id].get();
   waiting->ThenWaitFor(waited);
 }
 
-// Other function
-NcclComm::Lock CommGroup::AcquireComm(const AlpaNcclUid &key, int device_id) {
-  return comm_map[std::make_pair(key, device_id)].Acquire();
-}
 // Sync function
 Status ComputationWaitEvents(const AlpaUuids &uuids,
                              std::shared_ptr<PyClient> client) {
@@ -372,54 +188,10 @@ Status ComputationWaitEvents(const AlpaUuids &uuids,
   return OkStatus();
 }
 
-// Cross-mesh allreduce thunk related
-// TODO(yonghao): complete this
-void SetCommGroup(std::string key, CommGroup *g, const AlpaNcclUid uid) {
-  cross_mesh_comms.emplace(key, std::make_pair(g, uid));
-}
-
-NcclComm::Lock GetCommunicator(std::string key, size_t device_id) {
-  CrossMeshCommInfo& info = cross_mesh_comms.at(key);
-  return info.first->AcquireComm(info.second, device_id);
-}
-
 // Event context management
 void ResetEventContext(std::shared_ptr<PyClient> client) { ResetAlpaEvents(); }
+
 // Other functions
-AlpaNcclUid NcclUidSerialize(ncclUniqueId nccl_uid) {
-  AlpaNcclUid nccl_uid_vec(sizeof(nccl_uid.internal), 0);
-  memcpy(nccl_uid_vec.data(), &nccl_uid.internal, sizeof(nccl_uid.internal));
-  return nccl_uid_vec;
-}
-
-ncclUniqueId NcclUidDeserialize(const AlpaNcclUid &nccl_uid_vec) {
-  ncclUniqueId nccl_uid;
-  CHECK_EQ(sizeof(nccl_uid.internal), nccl_uid_vec.size());
-  memcpy(&nccl_uid.internal, nccl_uid_vec.data(), sizeof(nccl_uid.internal));
-  return nccl_uid;
-}
-
-StatusOr<AlpaNcclUid> NcclGetUniqueId() {
-#if XLA_ENABLE_XCCL
-  ncclUniqueId id;
-  XLA_CUDA_RETURN_IF_ERROR(ncclGetUniqueId(&id));
-  AlpaNcclUid nccl_uid_vec = NcclUidSerialize(id);
-  return nccl_uid_vec;
-#else   // XLA_ENABLE_XCCL
-  return Unimplemented("NCCL support is not available.");
-#endif  // XLA_ENABLE_XCCL
-}
-
-StatusOr<int> NcclGetVersion() {
-#if XLA_ENABLE_XCCL
-  int version;
-  XLA_CUDA_RETURN_IF_ERROR(ncclGetVersion(&version));
-  return version;
-#else   // XLA_ENABLE_XCCL
-  return Unimplemented("NCCL support is not available.");
-#endif  // XLA_ENABLE_XCCL
-}
-
 StatusOr<int> GetBufferDeviceId(PyBuffer::object buffer) {
   return buffer.buf()->device()->local_hardware_id();
 }

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.cc
@@ -179,6 +179,12 @@ void PyCommGroup::ComputeWaitComm(bool is_send, bool is_compute,
   waiting->ThenWaitFor(waited);
 }
 
+// Cross Mesh Communication
+void SetPyCommGroup(std::string key, std::shared_ptr<PyCommGroup> g,
+                    const AlpaNcclUid &uid) {
+  SetCommGroup(key, g, uid);
+}
+
 // Sync function
 Status ComputationWaitEvents(const AlpaUuids &uuids,
                              std::shared_ptr<PyClient> client) {

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -78,6 +78,8 @@ class CommGroup {
 
   void ComputeWaitComm(bool is_send, bool is_compute, int device_id);
 
+  NcclComm::Lock AcquireComm(const AlpaNcclUid &uuids, int device_id);
+
  private:
   std::vector<std::unique_ptr<se::Stream>> send_streams, recv_streams;
   ThreadSafeMap<std::pair<AlpaNcclUid, int>, NcclComm> comm_map;
@@ -92,6 +94,11 @@ class CommGroup {
 // ComputationWaitEvents
 Status ComputationWaitEvents(const AlpaUuids &uuids,
                              std::shared_ptr<PyClient> client);
+
+// Cross-mesh allreduce thunk related
+void SetCommGroup(std::string key, CommGroup *g, const AlpaNcclUid uid);
+
+NcclComm::Lock GetCommunicator(std::string key, size_t device_id);
 
 // Event context management
 void ResetEventContext(std::shared_ptr<PyClient> client);

--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_wrapper.h
@@ -70,6 +70,10 @@ class PyCommGroup : public CommGroup {
   void ComputeWaitComm(bool is_send, bool is_compute, int device_id);
 };
 
+// Cross Mesh Communication related
+void SetPyCommGroup(std::string key, std::shared_ptr<PyCommGroup> g,
+                    const AlpaNcclUid &uid);
+
 // We add them here rather than alpa_events to avoid circular deps in Bazel:
 // alpa_events > done_event_thunk > executable > client >
 // ComputationWaitEvents

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
@@ -486,10 +486,12 @@ NcclAllReduceConfig GetCrossMeshNcclAllReduceConfig(
 
 CrossMeshNcclAllReduceThunk::CrossMeshNcclAllReduceThunk(
     ThunkInfo thunk_info, std::vector<Buffer> buffers,
-    ReductionKind reduction_kind, xla::PrimitiveType op_type)
+    ReductionKind reduction_kind, xla::PrimitiveType op_type,
+    const std::string key)
     : Thunk(Thunk::kNcclAllReduce, thunk_info),
       buffers_(buffers),
-      config_(GetCrossMeshNcclAllReduceConfig(reduction_kind, op_type)) {}
+      config_(GetCrossMeshNcclAllReduceConfig(reduction_kind, op_type)),
+      key_(key) {}
 
 Status CrossMeshNcclAllReduceThunk::ExecuteOnStream(
     const ExecuteParams& params) {
@@ -506,7 +508,7 @@ Status CrossMeshNcclAllReduceThunk::ExecuteOnStream(
   // TODO(yonghao): support CrossMeshNcclAllReduce for different mesh groups as
   // above using participants info created at compile time
   int device_ordinal = params.stream->parent()->device_ordinal();
-  NcclComm::Lock comm = alpa::GetCommunicator(/*key=*/"", device_ordinal);
+  NcclComm::Lock comm = alpa::GetCommunicator(key_, device_ordinal);
 
   se::Stream& stream = *params.stream;
   TF_ASSIGN_OR_RETURN(

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
@@ -37,6 +37,9 @@ limitations under the License.
 #include "tensorflow/compiler/xla/stream_executor/gpu/gpu_activation.h"
 #endif
 
+// Added by Alpa
+#include "tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.h"
+
 namespace xla {
 namespace gpu {
 

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
@@ -157,11 +157,6 @@ class CrossMeshNcclAllReduceThunk : public Thunk {
   bool first_call_to_execute_ = true;
 };
 
-Status CreateCrossMeshCommunicator(int world_size,
-                                   const std::vector<int>& device_global_ranks,
-                                   int num_device,
-                                   const std::vector<int8_t>& nccl_uid_vec);
-
 }  // namespace gpu
 }  // namespace xla
 

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.h
@@ -147,7 +147,8 @@ class CrossMeshNcclAllReduceThunk : public Thunk {
   explicit CrossMeshNcclAllReduceThunk(ThunkInfo thunk_info,
                                        std::vector<Buffer> buffers,
                                        ReductionKind reduction_kind,
-                                       xla::PrimitiveType op_type);
+                                       xla::PrimitiveType op_type,
+                                       std::string key);
 
   Status ExecuteOnStream(const ExecuteParams& params) override;
 
@@ -155,6 +156,7 @@ class CrossMeshNcclAllReduceThunk : public Thunk {
   const NcclAllReduceConfig config_;
   const std::vector<Buffer> buffers_;
   bool first_call_to_execute_ = true;
+  std::string key_;
 };
 
 }  // namespace gpu


### PR DESCRIPTION
Currently we set cross-mesh communicator using a unique api different from our xla communicator group, and does not support multiple cross-mesh all-reduce groups. This PR fixes both.

TODO:
- [x] build a mapping from a cross-mesh-communicator's unique id to the key in `comm_map`;
- [x] record the unique id into the corresponding custom call and the `CrossMeshAllReduceThunk`;
- [x] apply the new pattern in the cupy version as well.

To help review, on the TF side, this PR:
- Record a key in the CrossMeshAllReduce custom call and its corresponding thunk (`ir_emitter_unnested.cc`, `nccl_all_reduce_thunk.*`);
- Create the cross-mesh communicator using `CommGroup`'s api, then record it with the key using a new function `SetCommGroup`(`alpa_nccl_group_base.*`). The thunk will get its communicator by `GetCommunicator`(same file);
- Split `PyCommGroup` from `CommGroup`. The `PyCommGroup` is responsible for synchronization at the `PyClient` level as well as passing `PjRtBuffer` to `CommGroup`. This is because now a nccl thunk requires an API related to `CommGroup`, but there is a circular dependency in python: `CommGroup` - `thunk` - `executable` - `client` - `CommGroup`.