### PR TITLE
[FIX] replace device_count by addressable_device_count

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/alpa_nccl_group_base.cc
@@ -106,7 +106,8 @@ CUstream default_stream = NULL;
 
 CommGroup::CommGroup(PjRtStreamExecutorClient *client) : client_(client) {
   if (client != nullptr) {
-    for (int device_id = 0; device_id < client->device_count(); ++device_id) {
+    for (int device_id = 0; device_id < client->addressable_device_count();
+         ++device_id) {
       auto executor = client->device_state(device_id).executor();
       auto i_stream = std::make_unique<se::Stream>(executor);
       auto o_stream = std::make_unique<se::Stream>(executor);


### PR DESCRIPTION
The semantic of `pjrt_client->device_count()` is the device number of all devices within the mesh, while `addressable_device_count` is those have address in local client, which is equal to local device number.
On the other hand, `pjrt_client->device_state(device_id)` is under the semantic of local devices, so the `device_id` here is the local device ordinal.